### PR TITLE
messages dates display to none

### DIFF
--- a/app/components/messages/box_component.html.erb
+++ b/app/components/messages/box_component.html.erb
@@ -4,7 +4,7 @@
   </p>
 
   <div class="flex justify-end gap-x-2">
-    <span class="invisible group-hover:visible text-sm text-aoc-gray-dark"><%= @message.created_at %></span>
+    <span class="hidden md:inline invisible group-hover:visible text-sm text-aoc-gray-dark"><%= @message.created_at %></span>
 
     <em class="text-sm text-aoc-gray-dark">
       - <%= link_to(@message.user.username, profile_path(@message.user.uid), class: "link-explicit group-hover:text-aoc-gray") %>


### PR DESCRIPTION
created_at span tag display changed to none with breakpoint update to inline at md for messages component from the Wall