### PR TITLE
feat(setup): add access to settings page during setup

### DIFF
--- a/app/components/header/nav_component.html.erb
+++ b/app/components/header/nav_component.html.erb
@@ -5,7 +5,6 @@
     <%= render NavTabComponent.new(link: { name: "calendar", path: calendar_path }) %>
     <%= render NavTabComponent.new(link: { name: "scores", path: scores_path }) %>
     <%= render NavTabComponent.new(link: { name: "the wall", path: messages_path }) %>
-    <%= render NavTabComponent.new(link: { name: "<i class=\"fas fa-gear\"></i>".html_safe, path: settings_path }) %>
 
   <% else %>
 
@@ -14,6 +13,7 @@
 
   <% end %>
 
+  <%= render NavTabComponent.new(link: { name: "<i class=\"fas fa-gear\"></i>".html_safe, path: settings_path }) %>
   <%= link_to destroy_user_session_path, class: "hover:text-wagon-red" do %>
     <i class="fas fa-power-off"></i>
   <% end %>

--- a/app/views/pages/setup.html.erb
+++ b/app/views/pages/setup.html.erb
@@ -103,7 +103,8 @@
         </p>
         <p>
           In the meantime, don't hesitate to have a look at the
-          <%= link_to "FAQ", faq_path, class: "link-explicit link-internal" %>.
+          <%= link_to "FAQ", faq_path, class: "link-explicit link-internal" %> or play with your account
+          <%= link_to "settings", settings_path, class: "link-explicit link-internal" %>.
         </p>
       </div>
     </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
   authenticated :user, ->(user) { !user.confirmed? } do
     get   "/",  to: "pages#setup", as: :setup
     patch "/",  to: "users#update"
+    get     "/settings",            to: "users#edit"
+    patch   "/settings",            to: "users#update"
   end
 
   # Routes for authenticated + confirmed users
@@ -45,8 +47,6 @@ Rails.application.routes.draw do
     post    "/squad/join",          to: "squads#join",      as: :join_squad
     delete  "/squad/leave",         to: "squads#leave",     as: :leave_squad
     get     "/profile/:uid",        to: "users#show",       as: :profile
-    get     "/settings",            to: "users#edit"
-    patch   "/settings",            to: "users#update"
   end
 
   # Admin routes


### PR DESCRIPTION
closes #201

## Summary of changes and context

I just changed the settings page authorization to be accessed despite not being confirmed yet.
I also modifed the text in the setup to redirect to the settings in the last step.

![image](https://github.com/pil0u/lewagon-aoc/assets/75388869/bb001965-2e73-46ba-bd42-e03e0a5d9457)


## Sanity checks

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
