### PR TITLE
feat(users): basic referrement system

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -74,7 +74,8 @@ class UsersController < ApplicationController
       # validation), then the id of that instance is nil, which disappears with .compact below
       city: City.find_by(id: form_params[:city_id]),
       entered_hardcore: form_params[:entered_hardcore],
-      username: form_params[:username]
+      username: form_params[:username],
+      referrer: User.by_referrer_code(form_params[:referrer_code])
     }.compact
   end
 
@@ -83,6 +84,6 @@ class UsersController < ApplicationController
   end
 
   def form_params
-    params.require(:user).permit(:accepted_coc, :aoc_id, :batch_number, :city_id, :entered_hardcore, :username)
+    params.require(:user).permit(:accepted_coc, :aoc_id, :batch_number, :city_id, :entered_hardcore, :username, :referrer_code)
   end
 end

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    content: String
+  }
+
+  copy() {
+    navigator.clipboard.writeText(this.contentValue)
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   belongs_to :batch, optional: true
   belongs_to :city, optional: true, touch: true
   belongs_to :squad, optional: true, touch: true
+  belongs_to :referrer, class_name: "User", optional: true
 
   has_many :completions, dependent: :destroy
   has_many :solo_points, class_name: "Cache::SoloPoint", dependent: :delete_all
@@ -18,6 +19,7 @@ class User < ApplicationRecord
   has_many :messages, dependent: :nullify
   has_many :snippets, dependent: :nullify
   has_many :achievements, dependent: :destroy
+  has_many :referrees, class_name: "User", inverse_of: :referrer, dependent: :nullify
 
   validates :aoc_id, numericality: { in: 1...(2**31), message: "should be between 1 and 2^31" }, allow_nil: true
   validates :aoc_id, uniqueness: { allow_nil: true }
@@ -70,5 +72,9 @@ class User < ApplicationRecord
     }
 
     css_class[sync_status]
+  end
+
+  def referrer_code
+    "R#{uid.to_s.rjust(5, '0')}"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,10 @@ class User < ApplicationRecord
     user
   end
 
+  def self.by_referrer_code(referrer_code)
+    User.find_by(uid: referrer_code&.gsub(/R0*/, "").to_i)
+  end
+
   def admin?
     uid.in?(ADMINS.values)
   end
@@ -75,6 +79,10 @@ class User < ApplicationRecord
   end
 
   def referrer_code
+    referrer&.referrement_code
+  end
+
+  def referrement_code
     "R#{uid.to_s.rjust(5, '0')}"
   end
 end

--- a/app/views/pages/setup.html.erb
+++ b/app/views/pages/setup.html.erb
@@ -12,7 +12,17 @@
     <span class="hover:text-wagon-red">Le Wagon</span> community. To unlock these features, please follow these steps:
   </p>
 
-  <ol class="ml-7 flex flex-col gap-y-3 list-decimal text-justify">
+  <ol start="0" class="ml-7 flex flex-col gap-y-3 list-decimal text-justify">
+    <li>
+      <p>Got referred by a friend? Enter their referral code here:</p>
+
+      <%= form_with model: current_user, url: setup_path, class: "flex flex-col items-center gap-y-2" do |f| %>
+        <div class="flex items-center gap-x-2">
+          <%= f.text_field :referrer_code, class: "input", placeholder: "R00000" %>
+          <%= f.submit "Save", class: "button" %>
+        </div>
+      <% end %>
+    </li>
     <li>
       <%= link_to(
             "Log in to Advent of Code",

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -4,6 +4,24 @@
 
 <hr class="my-4 border-aoc-gray-darker">
 
+<%= render PageTitleComponent.new(title: "Referrer code") %>
+
+<p>When you share the event to your friends, ask them to add this referral code during the setup. You will then become a patron..</p>
+
+<div class="my-4 flex flex-col justify-center gap-y-1 sm:flex-row sm:items-center sm:gap-x-3">
+  <label for="referrer_url">Referrer link</label>
+  <input type="text" value="<%= current_user.referrement_code %>" class="input" disabled>
+  <button
+    class="button"
+    data-controller="clipboard"
+    data-action="click->clipboard#copy"
+    data-clipboard-content-value="<%= current_user.referrement_code %>">
+    Copy
+  </button>
+</div>
+
+<hr class="my-4 border-aoc-gray-darker">
+
 <%= render PageTitleComponent.new(title: "Squad settings") %>
 
 <% if current_user.squad_id.nil? %>

--- a/db/migrate/20231101140441_add_referrer_reference_to_users.rb
+++ b/db/migrate/20231101140441_add_referrer_reference_to_users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddReferrerReferenceToUsers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :users, :referrer, index: { algorithm: :concurrently }
+  end
+end

--- a/db/migrate/20231101141144_add_referrer_foreign_key_to_users.rb
+++ b/db/migrate/20231101141144_add_referrer_foreign_key_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReferrerForeignKeyToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :users, :users, column: :referrer_id, validate: false
+  end
+end

--- a/db/migrate/20231101144409_validate_users_referrer_foreign_key.rb
+++ b/db/migrate/20231101144409_validate_users_referrer_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateUsersReferrerForeignKey < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :users, :users, column: :referrer_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_27_095046) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_01_144409) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -375,6 +375,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_27_095046) do
     t.boolean "entered_hardcore", default: false, null: false
     t.string "github_username"
     t.string "provider"
+    t.bigint "referrer_id"
     t.datetime "remember_created_at"
     t.text "remember_token"
     t.integer "squad_id"
@@ -385,6 +386,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_27_095046) do
     t.index ["aoc_id"], name: "index_users_on_aoc_id", unique: true
     t.index ["batch_id"], name: "index_users_on_batch_id"
     t.index ["city_id"], name: "index_users_on_city_id"
+    t.index ["referrer_id"], name: "index_users_on_referrer_id"
   end
 
   add_foreign_key "achievements", "users"
@@ -401,4 +403,5 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_27_095046) do
   add_foreign_key "squad_scores", "squads"
   add_foreign_key "users", "batches"
   add_foreign_key "users", "cities"
+  add_foreign_key "users", "users", column: "referrer_id"
 end


### PR DESCRIPTION
## Summary of changes and context
First step for #250 

The PR adds the references to the User model and some utilities
```ruby
User.by_referer_code("R00001") # => #<User uid: 1>

user.referrer # => #<User uid: 1>
user.referrees # => User::ActiveRecord_Associations_CollectionProxy
user.referrement_code # => "R00002" (uid of user is 2)
user.referrer_code # => "R00001"
```

It also adds a few reference to the Referrement system in the setup page and the settings page

- Setup 
![image](https://github.com/pil0u/lewagon-aoc/assets/75388869/38fda0ff-afc7-40ea-9c43-9ee72e5b8273)
- Settings 
![image](https://github.com/pil0u/lewagon-aoc/assets/75388869/5d3d0d9c-46c8-42d2-808a-f010af88044e)


## Sanity checks

<!-- Add more checks if you did more -->

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
