### PR TITLE
Fix: add has_many association between user_day_scores and users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   belongs_to :referrer, class_name: "User", optional: true
 
   has_many :completions, dependent: :destroy
+  has_many :user_day_scores, class_name: "Cache::UserDayScore", dependent: :delete_all
   has_many :solo_points, class_name: "Cache::SoloPoint", dependent: :delete_all
   has_many :solo_scores, class_name: "Cache::SoloScore", dependent: :delete_all
   has_many :insanity_points, class_name: "Cache::InsanityPoint", dependent: :delete_all


### PR DESCRIPTION
## Summary of changes and context

<!--
  Add related GitHub issues here with a keyword.

  Example: "Fixes #123456" or "Closes #123456"

  If multiple issues are involved, use a bulleted list:
  - Fixes #123456
  - Fixes #123457
-->

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [ ] Related GitHub issues are linked in the description
