### PR TITLE
Fix: do nothing if GitHub API does not respond with a 200

### DIFF
--- a/app/domains/achievements/github_star_mass_unlocker.rb
+++ b/app/domains/achievements/github_star_mass_unlocker.rb
@@ -4,8 +4,11 @@ module Achievements
   class GithubStarMassUnlocker < MassUnlocker
     def call
       uri = URI("https://api.github.com/repos/pil0u/lewagon-aoc/stargazers")
-      response = Net::HTTP.get(uri)
-      github_usernames = JSON.parse(response).pluck("login")
+      response = Net::HTTP.get_response(uri)
+
+      return unless response.code == "200"
+
+      github_usernames = JSON.parse(response.body).pluck("login")
       eligible_users = User.where(github_username: github_usernames)
 
       unlock_for!(eligible_users)


### PR DESCRIPTION
## Summary of changes and context

I received an error report from Sentry (in production), when the request to GitHub API for the "stars" achievement responded with a 403.

It happened 3 consecutive times, at 17:40, 17:50 and 18:00 (UTC)

We don't need to handle this, because it is triggered upon data update (every 10 minutes), so it will just work upon next refresh.

## Sanity checks

I ran the code in the console locally, with the new `get_response` method (to get the response code)

- [x] Linters pass
- [x] Tests pass
- [ ] Related GitHub issues are linked in the description
