### PR TITLE
feat(users): display referrees in settings

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,6 +41,18 @@ class UsersController < ApplicationController
 
   def edit
     @squad = Squad.find_or_initialize_by(id: current_user.squad_id)
+
+    return if current_user.referrees.count == 0
+
+    links = current_user.referrees.map do |referree|
+      "<a href='#{profile_path(referree.uid)}' class='strong hover:text-gold'>#{referree.username}</a>"
+    end
+
+    @referrees_links = case links.count
+                       when 1 then links.first
+                       when 2 then "#{links.first} and #{links.second}"
+                       else "#{links[0...].join(', ')} and #{links.last}"
+                       end
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,18 +41,8 @@ class UsersController < ApplicationController
 
   def edit
     @squad = Squad.find_or_initialize_by(id: current_user.squad_id)
-
-    return if current_user.referrees.count == 0
-
-    links = current_user.referrees.map do |referree|
-      "<a href='#{profile_path(referree.uid)}' class='strong hover:text-gold'>#{referree.username}</a>"
-    end
-
-    @referrees_links = case links.count
-                       when 1 then links.first
-                       when 2 then "#{links.first} and #{links.second}"
-                       else "#{links[0...].join(', ')} and #{links.last}"
-                       end
+    @squad_users_links = to_raw_links(@squad.users)
+    @referrees_links = to_raw_links(current_user.referrees)
   end
 
   def update
@@ -98,5 +88,18 @@ class UsersController < ApplicationController
 
   def form_params
     params.require(:user).permit(:accepted_coc, :aoc_id, :entered_hardcore, :username, :city_id, :referrer_code)
+  end
+
+  def to_raw_links(users)
+    links = users.map do |user|
+      "<a href='#{profile_path(user.uid)}' class='strong hover:text-gold'>#{user.username}</a>"
+    end
+
+    case links.length
+    when 0 then nil
+    when 1 then links.first
+    when 2 then "#{links.first} and #{links.second}"
+    else "#{links[0...-1].join(', ')} and #{links.last}"
+    end
   end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -58,3 +58,10 @@
     Copy
   </button>
 </div>
+
+<% if @referrees_links %>
+  <p>
+    You already referred <%= current_user.referrees.count %> users:
+    <%= sanitize @referrees_links %>
+  </p>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -20,7 +20,7 @@
 
 <% else %>
 
-  <p class="my-4">Members: <%= @squad.users.pluck(:username).join(", ") %></p>
+  <p class="my-4">Members: <%= sanitize @squad_users_links %></p>
 
   <%= form_with model: @squad, url: update_squad_path(@squad), class: "my-4 flex flex-col w-max mx-auto items-end gap-y-2" do |f| %>
     <div class="flex flex-col gap-y-1 sm:flex-row sm:items-center sm:gap-x-3">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -44,7 +44,9 @@
 
 <%= render PageTitleComponent.new(title: "Referral") %>
 
-<p class="my-4">When you share the event to your friends, ask them to add this referral code during the setup. You will then become a patron.</p>
+<p class="my-4">
+  When you share the event to your friends, ask them to add this referral code during the setup. This will boost your aura.
+</p>
 
 <div class="my-4 flex flex-col justify-center gap-y-1 sm:flex-row sm:items-center sm:gap-x-3">
   <input type="text" value="<%= current_user.referral_code %>" class="input" disabled autocomplete="off">


### PR DESCRIPTION
## Summary

closes https://github.com/pil0u/lewagon-aoc/issues/302

I didn't add an actual link on `aura` yet because the page does not exist until https://github.com/pil0u/lewagon-aoc/issues/304 is done. I'll update it in the next PR.

I went a bit beyond what was asked to integrate the text `and` in the displayed list of users because imo it's a detail that's worth doing.
```ruby
  def to_raw_links(users)
    links = users.map do |user|
      "<a href='#{profile_path(user.uid)}' class='strong hover:text-gold'>#{user.username}</a>"
    end

    case links.length
    when 0 then nil
    when 1 then links.first
    when 2 then "#{links.first} and #{links.second}"
    else "#{links[0...-1].join(', ')} and #{links.last}"
    end
  end
```

To display these raw anchor tags I simply use `<%= sanitize ... %>` instead of a regular `pe` tag. `sanitize` should keep us safe in case a user decide to go very fancy with its username which is the only user inputted value I render as html.
![image](https://github.com/pil0u/lewagon-aoc/assets/75388869/a9cc7c06-9189-4369-9476-eae889d6db16)


## Sanity checks

<!-- Add more checks if you did more -->

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
