### PR TITLE
Plug Batch info on Kitt callback and move back City on User to simplify validation logic.

### DIFF
--- a/app/components/user_form_component.html.erb
+++ b/app/components/user_form_component.html.erb
@@ -11,12 +11,12 @@
 
   <div class="flex flex-col gap-y-1 sm:flex-row sm:items-center sm:gap-x-3">
     <%= f.label :batch_number, "Batch #" %>
-    <%= f.number_field :batch_number, value: @user.batch&.number, min: 1, class: "input", disabled: true %>
+    <%= f.number_field :batch_number, value: @user.batch&.number, min: 1, class: "input", disabled: @user.batch_id? %>
   </div>
 
   <div class="flex flex-col gap-y-1 sm:flex-row sm:items-center sm:gap-x-3">
     <%= f.label :city_name, "Campus" %>
-    <%= f.collection_select(:city_id, City.order(:name), :id, :name, { prompt: "", selected: @user.batch&.city_id }, class: "input", disabled: @user.batch&.city_id?) %>
+    <%= f.collection_select(:city_id, City.order(:vanity_name), :id, :vanity_name, { prompt: "", selected: @user.city_id }, class: "input", disabled: @user.city_id?) %>
   </div>
 
   <div class="flex items-center gap-x-3 w-48 sm:w-fit">

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -86,18 +86,13 @@ class UsersController < ApplicationController
   end
 
   def updated_params
-    batch = nil
-
-    if current_user.batch_id.nil? && form_params[:city_id] # rubocop:disable Style/IfUnlessModifier
-      batch = Batch.find_or_create_by(number: nil, city_id: form_params[:city_id])
-    end
-
     {
       accepted_coc: form_params[:accepted_coc],
       aoc_id: form_params[:aoc_id],
       entered_hardcore: form_params[:entered_hardcore],
       username: form_params[:username],
-      batch_id: batch&.id,
+      batch_id: Batch.find_by(number: form_params[:batch_number])&.id,
+      city_id: form_params[:city_id],
       referrer: User.find_by_referral_code(form_params[:referrer_code])
     }.compact
   end
@@ -107,6 +102,6 @@ class UsersController < ApplicationController
   end
 
   def form_params
-    params.require(:user).permit(:accepted_coc, :aoc_id, :entered_hardcore, :username, :city_id, :referrer_code)
+    params.require(:user).permit(:accepted_coc, :aoc_id, :entered_hardcore, :username, :batch_number, :city_id, :referrer_code)
   end
 end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -2,7 +2,7 @@
 
 class Batch < ApplicationRecord
   has_many :users, dependent: :nullify
-  belongs_to :city
+  belongs_to :city, optional: true
 
   validates :number, numericality: { in: 1...(2**31), message: "should be between 1 and 2^31" }, allow_nil: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,14 +40,14 @@ class User < ApplicationRecord
 
   def self.from_kitt(auth)
     batches = auth.info&.schoolings
-    oldest_batch = batches.sort_by { |batch| batch.camp.starts_at }.first
+    oldest_batch = batches.min_by { |batch| batch.camp.starts_at }
 
     user = find_or_initialize_by(provider: auth.provider, uid: auth.uid) do |u|
       u.username = auth.info.github_nickname
 
       u.batch = Batch.find_or_initialize_by(number: oldest_batch&.camp&.slug) do |b|
         city = oldest_batch&.city
-        b.city =  City.find_or_initialize_by(name: city&.slug, vanity_name: city&.name)
+        b.city = City.find_or_initialize_by(name: city&.slug, vanity_name: city&.name)
       end
 
       u.city = u.batch.city

--- a/db/migrate/20231116030303_add_back_city_on_users.rb
+++ b/db/migrate/20231116030303_add_back_city_on_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddBackCityOnUsers < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 

--- a/db/migrate/20231116030303_add_back_city_on_users.rb
+++ b/db/migrate/20231116030303_add_back_city_on_users.rb
@@ -1,0 +1,8 @@
+class AddBackCityOnUsers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :users, :city, index: { algorithm: :concurrently }
+    add_foreign_key :users, :cities, validate: false
+  end
+end

--- a/db/migrate/20231116030521_add_foreign_key_for_users_city_relationship.rb
+++ b/db/migrate/20231116030521_add_foreign_key_for_users_city_relationship.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyForUsersCityRelationship < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :users, :cities
+  end
+end

--- a/db/migrate/20231116030521_add_foreign_key_for_users_city_relationship.rb
+++ b/db/migrate/20231116030521_add_foreign_key_for_users_city_relationship.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddForeignKeyForUsersCityRelationship < ActiveRecord::Migration[7.1]
   def change
     validate_foreign_key :users, :cities

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_01_144409) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_16_030521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -374,6 +374,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_01_144409) do
     t.boolean "accepted_coc", default: false, null: false
     t.integer "aoc_id"
     t.bigint "batch_id"
+    t.bigint "city_id"
     t.datetime "created_at", null: false
     t.boolean "entered_hardcore", default: false, null: false
     t.string "github_username"
@@ -389,6 +390,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_01_144409) do
     t.string "username"
     t.index ["aoc_id"], name: "index_users_on_aoc_id", unique: true
     t.index ["batch_id"], name: "index_users_on_batch_id"
+    t.index ["city_id"], name: "index_users_on_city_id"
     t.index ["referrer_id"], name: "index_users_on_referrer_id"
   end
 
@@ -406,5 +408,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_01_144409) do
   add_foreign_key "squad_points", "squads"
   add_foreign_key "squad_scores", "squads"
   add_foreign_key "users", "batches"
+  add_foreign_key "users", "cities"
   add_foreign_key "users", "users", column: "referrer_id"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     username { "pil0u" }
     synced { true }
     uid { id }
+    city_id { batch&.city_id }
   end
 end


### PR DESCRIPTION
## Summary of changes and context

Rework structure of User/Batch/City to better use new Kitt OAuth `schoolings` info.

## Sanity checks

<!-- Add more checks if you did more -->

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
