### PR TITLE
Fix provider conversion in OAuth failure message

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -46,7 +46,7 @@ module Users
     private
 
     def fail_auth(reason)
-      provider = request.env["omniauth.strategy"]&.name || "unknown"
+      provider = request.env["omniauth.strategy"]&.name&.to_s || "unknown"
 
       redirect_back(fallback_location: "/",
                     alert: "Failed to sign in with #{provider.titleize} (Reason: #{reason}).")


### PR DESCRIPTION
## Summary of changes and context

Sentry reported 2-3 users who failed to login, but on top of that they got a 500 because the provider is returned as a Symbol and not a String, and `titleize` does not exist for Symbols.

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [ ] Related GitHub issues are linked in the description
