### PR TITLE
feat(snippets): add horizontal scroll to snippets and custom scrollbar

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -95,6 +95,15 @@
     @apply fas fa-angles-up text-aoc-green text-opacity-50;
   }
 
+  .scrollbar-aoc::-webkit-scrollbar {
+    @apply h-1 w-1;
+  }
+
+  .scrollbar-aoc::-webkit-scrollbar-thumb {
+    @apply bg-aoc-gray-dark rounded-full group-hover:bg-aoc-gray;
+
+  }
+
   .strong {
     @apply text-white;
 

--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -5,7 +5,7 @@
       <%= Snippet::LANGUAGES[@snippet.language.to_sym] %>
     </span>
   </div>
-  <pre class="code-highlight text-sm whitespace-pre-wrap overflow-x-auto"><%= raw rouge(@snippet.code, @snippet.language) %></pre>
+  <pre class="code-highlight text-sm pb-2 scrollbar-aoc overflow-x-scroll"><%= raw rouge(@snippet.code, @snippet.language) %></pre>
 
   <div class="flex justify-end gap-x-2">
     <span class="invisible group-hover:visible text-sm text-aoc-gray-dark"><%= @snippet.created_at %></span>


### PR DESCRIPTION
## Summary of changes and context
closes #266 

I created a new class `scrollbar-aoc` to avoid having the gigantic default scrollbar on the snippets.
It's not easy to grab but I wanted to avoid making it too blocky.
I see it more as an indicator that people can scroll horizontaly here but they should probbaly be use SHIFT+scroll on hover which is way easier.
![image](https://github.com/pil0u/lewagon-aoc/assets/75388869/1f93cb1d-57a7-4d2e-b274-6119b9a1aaa8)


## Sanity checks

<!-- Add more checks if you did more -->

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
