### PR TITLE
fix(users): conflict between city association and original_city association

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,16 +56,17 @@ class User < ApplicationRecord
 
   def self.from_kitt(auth)
     oldest_batch = auth.info.schoolings&.min_by { |batch| batch.camp.starts_at }
+    city = City.find_or_initialize_by(name: oldest_batch&.city&.name)
 
     user = find_or_initialize_by(provider: auth.provider, uid: auth.uid) do |u|
       u.username = auth.info.github_nickname
 
       u.batch = Batch.find_or_initialize_by(number: oldest_batch&.camp&.slug.to_i)
-      u.city = City.find_or_initialize_by(name: oldest_batch&.city&.name)
+      u.city = city
     end
 
     user.github_username = auth.info.github_nickname
-    user.original_city = City.find_or_initialize_by(name: oldest_batch&.city&.name)
+    user.original_city_id = city&.id
 
     user.save
     user


### PR DESCRIPTION
## Summary of changes and context

En gros Rails s'emmelle les pinceau parce que les deux colonne sont lié a la meme table.
En modifiant le `original_city_id` ca regle le probleme

## Sanity checks

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
