### PR TITLE
Improve markdown snippets

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -29,7 +29,21 @@
   }
 
   .code-highlight pre {
-    @apply px-1 border border-aoc-gray-darker rounded;
+    @apply px-6 py-4 border border-aoc-gray-darker rounded;
+    @apply bg-dark !important;
+
+    position: relative;
+  }
+
+  .code-highlight pre:before {
+    content: attr(lang);
+    text-transform: capitalize;
+
+    position: absolute;
+    top: -1px;
+    right: -1px;
+
+    @apply px-2 border border-aoc-gray-darker text-aoc-gray font-medium text-sm rounded-tr;
   }
 
   details > summary {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -35,7 +35,7 @@
     position: relative;
   }
 
-  .code-highlight pre:before {
+  .code-highlight pre::before {
     content: attr(lang);
     text-transform: capitalize;
 

--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <pre class="code-highlight scrollbar-chrome text-sm overflow-x-auto">
-    <%= raw render_markdown @snippet.code %>
+    <%= raw render_markdown @snippet.code, default_language: @snippet.language %>
   </pre>
 
   <div class="pt-8 w-full flex items-center justify-between">

--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -3,7 +3,7 @@
     <%= link_to "⚓", snippet_path(day: @snippet.day, challenge: @snippet.challenge, anchor: @snippet.id) %>
   </div>
 
-  <pre class="code-highlight scrollbar-chrome text-sm overflow-x-auto" data-language=<%= @snippet.language %>>
+  <pre class="code-highlight scrollbar-chrome text-sm overflow-x-auto" data-language="<%= @snippet.language %>">
     <%= raw render_markdown @snippet.code, default_language: @snippet.language %>
   </pre>
 

--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -1,12 +1,9 @@
 <div id="<%= @snippet.id %>" class="w-full px-4 py-2 flex flex-col self-center gap-y-1 bg-aoc-gray-darkest border border-aoc-gray-dark group">
   <div class="flex justify-end text-sm gap-x-3">
     <%= link_to "⚓", snippet_path(day: @snippet.day, challenge: @snippet.challenge, anchor: @snippet.id) %>
-    <span class="px-2 bg-aoc-gray text-aoc-gray-darker font-semibold">
-      <%= Snippet::LANGUAGES[@snippet.language.to_sym] %>
-    </span>
   </div>
 
-  <pre class="code-highlight scrollbar-chrome text-sm overflow-x-auto">
+  <pre class="code-highlight scrollbar-chrome text-sm overflow-x-auto" data-language=<%= @snippet.language %>>
     <%= raw render_markdown @snippet.code, default_language: @snippet.language %>
   </pre>
 

--- a/app/domains/snippets/builder.rb
+++ b/app/domains/snippets/builder.rb
@@ -2,7 +2,6 @@
 
 module Snippets
   class Builder
-
     FENCE_TYPES = ["```", "~~~"].freeze
 
     def self.call(...)

--- a/app/domains/snippets/builder.rb
+++ b/app/domains/snippets/builder.rb
@@ -2,6 +2,9 @@
 
 module Snippets
   class Builder
+
+    FENCE_TYPES = ["```", "~~~"].freeze
+
     def self.call(...)
       new(...).call
     end
@@ -15,7 +18,10 @@ module Snippets
     end
 
     def markdown_wrapped(code, source_language:)
-      return code if code.include?("```") || source_language&.to_sym == :markdown
+      implicitly_markdown = FENCE_TYPES.any? { |fence| code.include?(fence) }
+      explicitly_markdown = source_language&.to_sym == :markdown
+
+      return code if implicitly_markdown || explicitly_markdown
 
       <<~CODE
         ```#{source_language}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,17 @@ module ApplicationHelper
 
   DEFAULT_THEME = "base16-ocean.dark"
 
-  def render_markdown(commonmarkdown)
-    Commonmarker.to_html(commonmarkdown, plugins: { syntax_highlighter: { theme: DEFAULT_THEME } })
+  def render_markdown(commonmarkdown, default_language: nil)
+    config = {}
+
+    config[:options] = {}
+    config[:options][:parse] = { default_info_string: default_language }.compact
+    config[:options][:render] = { escape: true }
+
+    config[:plugins] = {
+      syntax_highlighter: { theme: DEFAULT_THEME }
+    }
+
+    Commonmarker.to_html(commonmarkdown, **config)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,7 +23,7 @@ module ApplicationHelper
 
     config[:options] = {}
     config[:options][:parse] = { default_info_string: default_language }.compact
-    config[:options][:render] = { escape: true }
+    config[:options][:render] = { escape: true, github_pre_lang: true }
 
     config[:plugins] = {
       syntax_highlighter: { theme: DEFAULT_THEME }

--- a/spec/domains/snippets/builder_spec.rb
+++ b/spec/domains/snippets/builder_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Snippets::Builder do
+
+  let(:language) { :markdown }
+  let(:code) { <<-MARKDOWN }
+    Hello ! This is *my* solution !
+  MARKDOWN
+
+  it "builds a snippet with the provided attributes" do
+    result = described_class.call(code: code, language: language)
+    expect(result).to be_a Snippet
+    expect(result.attributes.symbolize_keys).to include(code: code, language: 'markdown')
+  end
+
+  context "when submitted straight code" do
+    let(:language) { :ruby }
+    let(:code) { <<-RUBY }
+      puts "My solution"
+    RUBY
+
+    it "wraps the code in a fenced block of specified language" do
+      result = described_class.call(code: code, language: language)
+      expect(result).to be_a Snippet
+      expect(result.attributes.symbolize_keys).to include(code: "```ruby\n#{code}\n```\n", language: 'ruby')
+    end
+  end
+end

--- a/spec/domains/snippets/builder_spec.rb
+++ b/spec/domains/snippets/builder_spec.rb
@@ -1,16 +1,17 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe Snippets::Builder do
-
   let(:language) { :markdown }
   let(:code) { <<-MARKDOWN }
     Hello ! This is *my* solution !
   MARKDOWN
 
   it "builds a snippet with the provided attributes" do
-    result = described_class.call(code: code, language: language)
+    result = described_class.call(code:, language:)
     expect(result).to be_a Snippet
-    expect(result.attributes.symbolize_keys).to include(code: code, language: 'markdown')
+    expect(result.attributes.symbolize_keys).to include(code:, language: "markdown")
   end
 
   context "when submitted straight code" do
@@ -20,9 +21,9 @@ RSpec.describe Snippets::Builder do
     RUBY
 
     it "wraps the code in a fenced block of specified language" do
-      result = described_class.call(code: code, language: language)
+      result = described_class.call(code:, language:)
       expect(result).to be_a Snippet
-      expect(result.attributes.symbolize_keys).to include(code: "```ruby\n#{code}\n```\n", language: 'ruby')
+      expect(result.attributes.symbolize_keys).to include(code: "```ruby\n#{code}\n```\n", language: "ruby")
     end
   end
 end


### PR DESCRIPTION
## Summary of changes and context

Follow-up de #342. Inclut:
- Gestion des fences `~~~` (qui sont autorisés par la spec)
- Optionalité des info-strings (même sans le `ruby` après les backticks, on colore quand même basé sur le language du snippet)
- Styling
- Spec
  - Avant<br><img width="1092" alt="Capture d’écran 2023-12-01 à 14 24 06" src="https://github.com/pil0u/lewagon-aoc/assets/2871879/8395acdf-7bf9-4157-ba15-88d69bb7b44f">
  - Après<br><img width="1059" alt="Capture d’écran 2023-12-01 à 14 21 41" src="https://github.com/pil0u/lewagon-aoc/assets/2871879/b9da3274-da0e-45b9-be8d-20c5bff97ea4">


## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
