### PR TITLE
fix(snippets): Some style bug fixes

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -28,22 +28,35 @@
     @apply px-1 bg-aoc-gray-darkest border border-aoc-gray-darker rounded;
   }
 
-  .code-highlight pre {
-    @apply px-6 py-4 border border-aoc-gray-darker rounded;
-    @apply bg-dark !important;
+  .code-highlight * {
+    @apply last:mb-0
+  }
 
-    position: relative;
+  .code-highlight h1 {
+    @apply border-aoc-gray-darker border-b font-semibold mb-4 pb-2 text-4xl
+  }
+
+  .code-highlight h2 {
+    @apply border-aoc-gray-darker border-b font-semibold my-4 pb-1.5 text-2xl
+  }
+
+  .code-highlight h3 {
+    @apply font-semibold my-4 text-lg
+  }
+
+  .code-highlight pre {
+    @apply !bg-dark border border-aoc-gray-darker my-4 rounded relative;
   }
 
   .code-highlight pre::before {
+    @apply absolute border-aoc-gray-darker border-b border-l capitalize font-medium px-2 right-0
+    rounded-bl top-0 text-aoc-gray text-sm;
+
     content: attr(lang);
-    text-transform: capitalize;
+  }
 
-    position: absolute;
-    top: -1px;
-    right: -1px;
-
-    @apply px-2 border border-aoc-gray-darker text-aoc-gray font-medium text-sm rounded-tr;
+  .code-highlight pre code {
+    @apply block pb-4 pt-6 px-6 overflow-x-scroll scrollbar-chrome w-full;
   }
 
   details > summary {

--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -3,7 +3,7 @@
     <%= link_to "⚓", snippet_path(day: @snippet.day, challenge: @snippet.challenge, anchor: @snippet.id) %>
   </div>
 
-  <pre class="code-highlight scrollbar-chrome text-sm overflow-x-auto" data-language="<%= @snippet.language %>">
+  <pre class="code-highlight break-words text-sm whitespace-normal" data-language="<%= @snippet.language %>">
     <%= raw render_markdown @snippet.code, default_language: @snippet.language %>
   </pre>
 

--- a/app/components/snippets/reaction_component.html.erb
+++ b/app/components/snippets/reaction_component.html.erb
@@ -1,5 +1,5 @@
 <div class="relative group/reaction">
-  <div class="absolute bg-aoc-gray-darker bottom-full hidden mb-1 px-2 py-0.5 right-1/2 rounded shadow-black shadow-lg text-xs translate-x-1/2 w-max group-hover/reaction:block">
+  <div class="absolute bg-aoc-gray-darker bottom-full hidden mb-2 px-2 py-0.5 right-1/2 rounded shadow-black shadow-lg text-xs translate-x-1/2 w-max group-hover/reaction:block">
     <%= EMOTES[@reaction_type][:tooltip] %>
   </div>
 


### PR DESCRIPTION
## Summary of changes and context

Part of https://github.com/pil0u/lewagon-aoc/issues/387

I moved the scrollbar to the code blocks, added spacing between the language name and the code and updated the header styles

![image](https://github.com/pil0u/lewagon-aoc/assets/75388869/b4592969-e355-4a4e-a7db-62b25fb3fcba)

## Sanity checks

<!-- Add more checks if you did more -->

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
