### PR TITLE
Move from Heroku to Dokku (on Scaleway)

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,0 +1,24 @@
+name: Deploy production
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push to Scaleway Dokku
+        uses: dokku/github-action@master
+        with:
+          command: deploy
+          git_remote_url: "ssh://dokku@aoc.lewagon.engineering/aoc"
+          git_push_flags: "--force -vvv"
+          ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          ssh_host_key: |
+            aoc.lewagon.engineering ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCdhe2e12VHkgquDfT9sFDSG1O4WXs/B7R1eew/kfPHfQkxHRrA+qxML0QdUKKJFBAJb2raXb2kcQIavgkZCwIy/b+vjjHT4k5HWWkmWehr6jwhIg9lxDXN+9akc7ocit/rZA7Xai2LIU0h+Orh+0qoinhB3ANPIDgF8XARjpAgQkGPDqCfi/EL4OhcBq51eUp8UdjKo7GaBL+zEn1ehpyJoDZgKOYqN8eRaVsJZ59PBVSuedqRR5tJpMpM74faLHsixfT7BcDfvvBAU2H2ZXXptiNbjdLiZo0SHymYlpUHvyt7xc0H0mm0/xEFT0Z1qzbC+pULzskwuS4lqtJxN6W7W+V7rgBkKFM5MB87ykvF8wB+VmJS4RnXKB2ZrAcAFsEJ+EyUI1jDdNJuzpvcXj9+BecfDw8ar1312lgZEFzzCgjZfy/666cZQFyDAl5hK6pCWVbLXme49Kxz6Ktj18PXCERT6XYhGoPotJ8j1HL9yYLbWg3WnqdAO8OAB+mvAAs=

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,24 @@
+name: Deploy staging
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push to Scaleway Dokku
+        uses: dokku/github-action@master
+        with:
+          command: deploy
+          git_remote_url: "ssh://dokku@aoc.lewagon.engineering/aoc-staging"
+          git_push_flags: "--force -vvv"
+          ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          ssh_host_key: |
+            aoc.lewagon.engineering ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCdhe2e12VHkgquDfT9sFDSG1O4WXs/B7R1eew/kfPHfQkxHRrA+qxML0QdUKKJFBAJb2raXb2kcQIavgkZCwIy/b+vjjHT4k5HWWkmWehr6jwhIg9lxDXN+9akc7ocit/rZA7Xai2LIU0h+Orh+0qoinhB3ANPIDgF8XARjpAgQkGPDqCfi/EL4OhcBq51eUp8UdjKo7GaBL+zEn1ehpyJoDZgKOYqN8eRaVsJZ59PBVSuedqRR5tJpMpM74faLHsixfT7BcDfvvBAU2H2ZXXptiNbjdLiZo0SHymYlpUHvyt7xc0H0mm0/xEFT0Z1qzbC+pULzskwuS4lqtJxN6W7W+V7rgBkKFM5MB87ykvF8wB+VmJS4RnXKB2ZrAcAFsEJ+EyUI1jDdNJuzpvcXj9+BecfDw8ar1312lgZEFzzCgjZfy/666cZQFyDAl5hK6pCWVbLXme49Kxz6Ktj18PXCERT6XYhGoPotJ8j1HL9yYLbWg3WnqdAO8OAB+mvAAs=

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ config/master.key
 !/app/assets/builds/.keep
 
 coverage
+
+# SSH Keypair for GitHub Action
+gha_ed25519
+gha_ed25519.pub


### PR DESCRIPTION
Moving the two apps from Heroku to Dokku (running on a dedicated `DEV1-S` instance at `aoc.lewagon.engineering`):

```bash
ssh dokku@aoc.lewagon.engineering apps:list
```

I added @pil0u's SSH key with:

```bash
curl https://github.com/pil0u.keys | ssh root@aoc dokku ssh-keys:add "pil0u"
```

If more people need access, ping me here.

I advise you to open your `~/.ssh/config` and add:

```bash
Host aoc
  Hostname aoc.lewagon.engineering
  User dokku
```

That way you can run simpler commands like:

```bash
# Getting logs (of prod or staging app)
ssh aoc logs aoc --tail
ssh aoc logs aoc-staging --tail # not repeating below, but you get the gist.

# Environment variables
ssh aoc config aoc

# Running processes
ssh aoc ps:report aoc

# Start a Rails console
ssh -t aoc run aoc bin/rails c
```

This PR adds two GitHub actions to have CI/CD of:

- Production app `aoc.lewagon.community` on `release` branch
- Staging app `aoc-staging.lewagon.community` on `main` branch