### PR TITLE
Rework some navigation links

### DIFF
--- a/app/components/footer/nav_component.html.erb
+++ b/app/components/footer/nav_component.html.erb
@@ -1,18 +1,10 @@
 <nav>
 
+  <%= link_to "code of conduct", code_of_conduct_path, class: "link-explicit" %>
+  <%= link_to "stats", stats_path, class: "link-explicit" %>
+
   <% if @user && @user.confirmed? %>
-
-    <%= link_to "code of conduct", code_of_conduct_path, class: "link-explicit" %>
-    <%= link_to "stats", stats_path, class: "link-explicit" %>
     <%= link_to "the wall", messages_path, class: "link-explicit" %>
-    <%= link_to "community", Aoc.slack_channel, target: :_blank, rel: :noopener, class: "link-explicit link-slack" %>
-
-  <% else %>
-
-    <%= link_to "code of conduct", code_of_conduct_path, class: "link-explicit" %>
-    <%= link_to "stats", stats_path, class: "link-explicit" %>
-    <%= link_to "community", Aoc.slack_channel, target: :_blank, rel: :noopener, class: "link-explicit link-slack" %>
-
   <% end %>
 
 </nav>

--- a/app/components/footer/nav_component.html.erb
+++ b/app/components/footer/nav_component.html.erb
@@ -4,7 +4,6 @@
 
     <%= link_to "code of conduct", code_of_conduct_path, class: "link-explicit" %>
     <%= link_to "stats", stats_path, class: "link-explicit" %>
-    <%= link_to "patrons", patrons_path, class: "link-explicit" %>
     <%= link_to "the wall", messages_path, class: "link-explicit" %>
     <%= link_to "community", Aoc.slack_channel, target: :_blank, rel: :noopener, class: "link-explicit link-slack" %>
 

--- a/app/components/header/nav_component.html.erb
+++ b/app/components/header/nav_component.html.erb
@@ -5,6 +5,7 @@
     <%= render NavTabComponent.new(link: { name: "calendar", path: calendar_path }) %>
     <%= render NavTabComponent.new(link: { name: "faq", path: faq_path }) %>
     <%= render NavTabComponent.new(link: { name: "settings", path: settings_path }) %>
+    <%= render NavTabComponent.new(link: { name: "patrons", path: patrons_path }) %>
     <%= render NavTabComponent.new(link: { name: "admin", path: admin_path }) if @user.admin? %>
 
   <% else %>

--- a/app/components/header/nav_component.html.erb
+++ b/app/components/header/nav_component.html.erb
@@ -3,20 +3,20 @@
   <% if @user.confirmed? %>
 
     <%= render NavTabComponent.new(link: { name: "calendar", path: calendar_path }) %>
-    <%= render NavTabComponent.new(link: { name: "faq", path: faq_path }) %>
     <%= render NavTabComponent.new(link: { name: "settings", path: settings_path }) %>
     <%= render NavTabComponent.new(link: { name: "patrons", path: patrons_path }) %>
-    <%= render NavTabComponent.new(link: { name: "admin", path: admin_path }) if @user.admin? %>
 
   <% else %>
 
-    <%= render NavTabComponent.new(link: { name: "faq", path: faq_path }) %>
     <%= render NavTabComponent.new(link: { name: "setup", path: setup_path }) %>
 
   <% end %>
 
+  <%= render NavTabComponent.new(link: { name: "faq", path: faq_path }) %>
   <%= link_to destroy_user_session_path, class: "hover:text-wagon-red" do %>
     <i class="fas fa-power-off"></i>
   <% end %>
+
+  <%= render NavTabComponent.new(link: { name: "admin", path: admin_path }) if @user.admin? %>
 
 </nav>

--- a/app/components/header/title_component.html.erb
+++ b/app/components/header/title_component.html.erb
@@ -1,7 +1,13 @@
-<h1 class="my-8 text-center text-xl group">
-  <%= link_to "/" do %>
-    <span class="text-wagon-red group-hover:text-shadow-red">Le Wagon</span>
-    <span class="group-hover:strong">x</span>
-    <span class="text-other-green group-hover:text-shadow-green">Advent of Code</span>
+<div>
+  <h1 class="my-8 text-center text-xl group">
+    <%= link_to "/" do %>
+      <span class="text-wagon-red group-hover:text-shadow-red">Le Wagon</span>
+      <span class="group-hover:strong">x</span>
+      <span class="text-other-green group-hover:text-shadow-green">Advent of Code</span>
+    <% end %>
+  </h1>
+
+  <% if current_page?("/") %>
+    <%= link_to "#aoc on Slack!", Aoc.slack_channel, target: :_blank, rel: :noopener, class: "hidden lg:block absolute top-9 right-9 -rotate-[8deg] text-sm link-slack" %>
   <% end %>
-</h1>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,6 @@ Rails.application.routes.draw do
   # Public routes
   get "/code-of-conduct", to: "pages#code_of_conduct"
   get "/faq",             to: "pages#faq"
-  get "/participation",   to: "pages#participation"
   get "/stats",           to: "pages#stats"
 
   # Routes for unauthenticated users
@@ -90,6 +89,7 @@ Rails.application.routes.draw do
     get   "/scores/squads",   to: "scores#squads"
     get   "/scores/campuses", to: "scores#campuses"
     get   "/scores/insanity", to: "scores#insanity"
+    get   "/participation",   to: "pages#participation"
 
     mount Blazer::Engine,     at: "blazer"
     mount GoodJob::Engine,    at: "good_job"


### PR DESCRIPTION
## Summary of changes and context

- Closes #490 
- Closes #515 
- Closes #533 

Moved around navigation links.
Make `/participation` admin-only.
Show a link to Slack in the header on `/`.

<img width="1512" alt="Screenshot 2024-06-09 at 10 45 16" src="https://github.com/pil0u/lewagon-aoc/assets/8350914/5da40483-d893-4c81-a128-d894a818db46">

<!--
  Add related GitHub issues here with a keyword.

  Example: "Fixes #123456" or "Closes #123456"

  If multiple issues are involved, use a bulleted list:
  - Fixes #123456
  - Fixes #123457
-->

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
