### PR TITLE
Update the aura formula for referrals

### DIFF
--- a/app/views/pages/patrons.html.erb
+++ b/app/views/pages/patrons.html.erb
@@ -28,8 +28,8 @@
   </code>
 
   <p>
-    Every time someone signs up using your code, you will increase your <span class="strong">aura</span>. Finding people
-    who solve a few puzzles can only help your <span class="strong">aura</span> as well.
+    Every signup using your code will increase your <span class="strong">aura</span>. Referring people who solve a few
+    puzzles or share their solution can only help your <span class="strong">aura</span> as well.
   </p>
 
   <p>
@@ -41,11 +41,10 @@
   </p>
 </div>
 
-<table class="block overflow-x-auto whitespace-nowrap w-full max-w-lg mx-auto">
+<table class="block overflow-x-auto whitespace-nowrap w-full max-w-md mx-auto">
   <thead>
     <tr class="border-b border-aoc-gray-darker">
       <th class="font-light w-full"></th>
-      <th class="font-light min-w-[6rem]">Referrals</th>
       <th class="font-light min-w-[6rem]">Aura</th>
     </tr>
   </thead>
@@ -57,12 +56,8 @@
           <%= link_to user["username"], profile_path(user["uid"]), class: "hover:text-gold" %>
         </td>
 
-        <td class="text-center">
-          <%= user["referrals"] %>
-        </td>
-
         <td class="text-center strong">
-          <%= user["aura"].to_i %>
+          <%= user["aura"] %>
         </td>
       </tr>
     <% end %>

--- a/spec/factories/snippets.rb
+++ b/spec/factories/snippets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :snippet do
+    association :user
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,13 +29,28 @@ RSpec.describe User do
       referee_three = create(:user, username: "Aurrou", uid: "4", referrer:)
       create(:user, username: "Nikos", uid: "5", referrer: referee_one)
 
-      create_list(:completion, 1, user: referee_one)
-      create_list(:completion, 2, user: referee_two)
-      create_list(:completion, 3, user: referee_three)
+      build_list(:completion, 3, user: referee_one) do |completion, i|
+        completion.day = i + 1
+        completion.save!
+      end
+      build_list(:completion, 5, user: referee_two) do |completion, i|
+        completion.day = i + 1
+        completion.save!
+      end
+      build_list(:completion, 8, user: referee_three) do |completion, i|
+        completion.day = i + 1
+        completion.save!
+      end
+
+      create(:snippet, user: referee_one, language: "ruby", code: "some code")
+      create(:snippet, user: referee_one, language: "python", code: "some code")
+      create(:snippet, user: referee_two, language: "ruby", code: "some code")
+      create(:snippet, user: referee_two, language: "python", code: "some code")
+      create(:snippet, user: referee_two, language: "javascript", code: "some code")
 
       expect(User.with_aura).to contain_exactly(
-        hash_including("uid" => "1", "username" => "pil0u", "referrals" => 3, "aura" => 832.0), # (100 * (ln(3 + 1) + 2 * (1 + 1) + 3 * (1 + 1) + 5 * (1 + 1))).ceil
-        hash_including("uid" => "2", "username" => "Aquaj", "referrals" => 1, "aura" => 70.0) # (100 * (ln(1 + 1) + 2 * (0 + 1) + 3 * (0 + 1) + 5 * (0 + 1))).ceil
+        hash_including("uid" => "1", "username" => "pil0u", "referrals" => 3, "aura" => 1919),  # (100 * (ln(3+1) + (ln(3+1) + ln(5+1) + ln(8+1)) + 5 * (ln(2+1) + ln(3+1)))).ceil
+        hash_including("uid" => "2", "username" => "Aquaj", "referrals" => 1, "aura" => 70)     # (100 * (ln(1+1) + 0                             + 5 * 0)).ceil
       )
     end
   end


### PR DESCRIPTION
## Summary of changes and context

- Closes #516 
- Closes #517 

New formula for referrals includes and emphasises on contributions (i.e. solutions shared), and also makes the completions more "linear" (e.g. a referee who solves 2 puzzles would contribute, but less than one who solves 20).

Tests were not deterministic for some reason (randomised completion day), I fixed them.

<!--
  Add related GitHub issues here with a keyword.

  Example: "Fixes #123456" or "Closes #123456"

  If multiple issues are involved, use a bulleted list:
  - Fixes #123456
  - Fixes #123457
-->

## Sanity checks

<!-- Add more checks if you did more -->

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
