### PR TITLE
Make all users opt-in the Ladder of Insanity

### DIFF
--- a/app/components/user_form_component.html.erb
+++ b/app/components/user_form_component.html.erb
@@ -24,16 +24,6 @@
     <%= f.select :favourite_language, Snippet::LANGUAGES.invert.to_a, { prompt: "", selected: @user.favourite_language }, class: "input self-end" %>
   </div>
 
-  <div class="flex items-center gap-x-3">
-    <%= f.label :entered_hardcore, "Join the Ladder of Insanity" %>
-    <%= f.check_box :entered_hardcore, checked: @user.entered_hardcore, class: "focus:no-ring", data: {
-          controller: "check-alert",
-          check_alert_target: "checkbox",
-          action: "change->check-alert#ping",
-          check_alert_message_value: "The Ladder of Insanity is opt-in. By #{@lock_day}, your choice will be immutable.\n\nIf you decide to join, you will appear in the specific ranking and be eligible to its rewards. However, you will lose eligibility to the rewards of the casual ranking."
-        } %>
-  </div>
-
   <div class="flex flex-col gap-y-1 sm:flex-row sm:items-center sm:gap-x-3">
     <%= f.label :event_awareness, "How did you hear about us? 💡" %>
     <%= f.select :event_awareness, UserFormComponent::AWARENESS_OPTIONS.invert.to_a, { prompt: "", selected: @user.event_awareness }, class: "input self-end pr-8 text-ellipsis" %>

--- a/app/components/user_form_component.rb
+++ b/app/components/user_form_component.rb
@@ -16,6 +16,5 @@ class UserFormComponent < ApplicationComponent
 
   def initialize(user:)
     @user = user
-    @lock_day = "December #{Aoc.lewagon_lock_time.day.ordinalize}"
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,6 @@
 
 class UsersController < ApplicationController
   before_action :authenticate_admin, only: %i[impersonate]
-  before_action :restrict_after_lock, only: %i[update]
 
   def show
     @user = User.find_by!(uid: params[:uid])
@@ -89,15 +88,6 @@ class UsersController < ApplicationController
     redirect_to root_path
   end
 
-  def restrict_after_lock
-    return unless Time.now.utc > Aoc.lewagon_lock_time && (user_params[:entered_hardcore] == "1") != current_user.entered_hardcore
-
-    redirect_back(
-      fallback_location: "/",
-      alert: "You cannot join or leave the Ladder of Insanity since #{Aoc.lewagon_lock_time.to_fs(:long_ordinal)} (see FAQ)"
-    )
-  end
-
   def unlock_achievements
     Achievements::UnlockJob.perform_later(:city_join, current_user.id)
   end
@@ -105,6 +95,6 @@ class UsersController < ApplicationController
   def user_params
     params
       .require(:user)
-      .permit(:accepted_coc, :aoc_id, :city_id, :entered_hardcore, :event_awareness, :favourite_language, :username)
+      .permit(:accepted_coc, :aoc_id, :city_id, :event_awareness, :favourite_language, :username)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,7 @@ class User < ApplicationRecord
 
   scope :admins, -> { where(uid: ADMINS.values) }
   scope :confirmed, -> { where(accepted_coc: true, synced: true).where.not(aoc_id: nil) }
-  scope :insanity, -> { where(entered_hardcore: true) }
+  scope :insanity, -> { where(entered_hardcore: true) } # All users are 'hardcore' since 2024 edition
   scope :contributors, -> { where(uid: CONTRIBUTORS.values) }
   scope :slack_linked, -> { where.not(slack_id: nil) }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,8 @@ module LewagonAoc
 
     # Use GoodJob as ActiveJob backend
     config.active_job.queue_adapter = :good_job
+
+    # Disable partial writes when changing default values
+    config.active_record.partial_inserts = false
   end
 end

--- a/db/migrate/20240920133223_set_entered_hardcore_default_true.rb
+++ b/db/migrate/20240920133223_set_entered_hardcore_default_true.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SetEnteredHardcoreDefaultTrue < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :users, :entered_hardcore, from: false, to: true
+  end
+end

--- a/db/migrate/20240920133907_set_all_users_to_entered_hardcore.rb
+++ b/db/migrate/20240920133907_set_all_users_to_entered_hardcore.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SetAllUsersToEnteredHardcore < ActiveRecord::Migration[7.1]
+  def up
+    User.update_all(entered_hardcore: true)
+  end
+
+  def down
+    Rails.logger.warn("WARN: Nothing to do here, this migration was irreversible.")
+  end
+end

--- a/db/migrate/20240920143615_add_not_null_contraint_hardcore.rb
+++ b/db/migrate/20240920143615_add_not_null_contraint_hardcore.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullContraintHardcore < ActiveRecord::Migration[7.1]
+  def change
+    add_check_constraint :users, "entered_hardcore IS NOT NULL", name: "users_entered_hardcore_null", validate: false
+  end
+end

--- a/db/migrate/20240920164719_validate_not_null_constraint_hardcore.rb
+++ b/db/migrate/20240920164719_validate_not_null_constraint_hardcore.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidateNotNullConstraintHardcore < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :users, name: "users_entered_hardcore_null"
+    change_column_null :users, :entered_hardcore, false
+    remove_check_constraint :users, name: "users_entered_hardcore_null"
+  end
+
+  def down
+    add_check_constraint :users, "entered_hardcore IS NOT NULL", name: "users_entered_hardcore_null", validate: false
+    change_column_null :users, :entered_hardcore, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_20_133907) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_20_164719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -404,7 +404,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_133907) do
     t.bigint "batch_id"
     t.bigint "city_id"
     t.datetime "created_at", null: false
-    t.boolean "entered_hardcore", default: true
+    t.boolean "entered_hardcore", default: true, null: false
     t.integer "event_awareness"
     t.string "favourite_language"
     t.string "github_username"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_19_205503) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_20_133907) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -404,7 +404,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_19_205503) do
     t.bigint "batch_id"
     t.bigint "city_id"
     t.datetime "created_at", null: false
-    t.boolean "entered_hardcore", default: false, null: false
+    t.boolean "entered_hardcore", default: true
     t.integer "event_awareness"
     t.string "favourite_language"
     t.string "github_username"


### PR DESCRIPTION
## Summary of changes and context

Strategy: keep the `entered_hardcore` attribute and:
* set it to `true`  by default for new users
* mark it `true`  for all current users
* make it not changeable by the users

Closes #491 

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
