### PR TITLE
Update insanity scoring

### DIFF
--- a/app/domains/scores/insanity_points.rb
+++ b/app/domains/scores/insanity_points.rb
@@ -19,10 +19,11 @@ module Scores
       completions = Completion
                     .joins(:user).merge(User.insanity)
                     .select(Arel.sql("completions.*"), Arel.sql(<<~SQL.squish))
-                      (SELECT COUNT(*) FROM users WHERE entered_hardcore AND synced)
-                      - (rank() OVER (PARTITION BY day, challenge ORDER BY completion_unix_time ASC))
-                      + 1
-                      AS score
+                      CASE
+                        WHEN rank() OVER (PARTITION BY day, challenge ORDER BY completion_unix_time ASC) <= 5 THEN
+                          6 - rank() OVER (PARTITION BY day, challenge ORDER BY completion_unix_time ASC)
+                        ELSE 0
+                      END AS score
                     SQL
 
       completions.map do |completion|

--- a/spec/domains/scores/insanity_points_spec.rb
+++ b/spec/domains/scores/insanity_points_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Scores::InsanityPoints do
 
   let!(:completions) do
     [
-      create_completion(1, 1, user_1, 3.hours + 25.minutes),
-      create_completion(1, 2, user_1, 1.day + 12.minutes),
-      create_completion(1, 1, user_2, 3.days + 1.minute)
+      create_completion(day: 1, challenge: 1, user: user_1, duration: 3.hours + 25.minutes),
+      create_completion(day: 1, challenge: 2, user: user_1, duration: 1.day + 12.minutes),
+      create_completion(day: 1, challenge: 1, user: user_2, duration: 3.days + 1.minute)
     ]
   end
 
@@ -24,15 +24,17 @@ RSpec.describe Scores::InsanityPoints do
            completion_unix_time: completion_timestamp.to_i)
   end
 
-  it "computes the points for users for each challenge" do
-    expect(described_class.get).to contain_exactly(
-      { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
-      { score: 5, user_id: 1, day: 1, challenge: 2, completion_id: completions[1].id },
-      { score: 4, user_id: 2, day: 1, challenge: 1, completion_id: completions[2].id }
-    )
+  describe "#get" do
+    it "computes the points for users for each challenge" do
+      expect(described_class.get).to contain_exactly(
+        { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
+        { score: 5, user_id: 1, day: 1, challenge: 2, completion_id: completions[1].id },
+        { score: 4, user_id: 2, day: 1, challenge: 1, completion_id: completions[2].id }
+      )
+    end
   end
 
-  describe "scoring" do
+  describe "scoring system" do
     let!(:user_3) { create(:user, id: 3, entered_hardcore: true) }
     let!(:user_4) { create(:user, id: 4, entered_hardcore: true) }
     let!(:user_5) { create(:user, id: 5, entered_hardcore: true) }
@@ -41,17 +43,17 @@ RSpec.describe Scores::InsanityPoints do
 
     let!(:completions) do
       [
-        create_completion(1, 1, user_1, 3.hours + 25.minutes),
-        create_completion(1, 1, user_2, 1.day + 2.hours),
-        create_completion(1, 1, user_3, 3.hours + 26.minutes),
-        create_completion(1, 1, user_4, 3.days + 1.minute),
-        create_completion(1, 1, user_5, 4.hours),
-        create_completion(1, 1, user_6, 4.hours + 3.minutes),
-        create_completion(1, 1, user_7, 4.hours + 5.minutes)
+        create_completion(day: 1, challenge: 1, user: user_1, duration: 3.hours + 25.minutes),
+        create_completion(day: 1, challenge: 1, user: user_2, duration: 1.day + 2.hours),
+        create_completion(day: 1, challenge: 1, user: user_3, duration: 3.hours + 26.minutes),
+        create_completion(day: 1, challenge: 1, user: user_4, duration: 3.days + 1.minute),
+        create_completion(day: 1, challenge: 1, user: user_5, duration: 4.hours),
+        create_completion(day: 1, challenge: 1, user: user_6, duration: 4.hours + 3.minutes),
+        create_completion(day: 1, challenge: 1, user: user_7, duration: 4.hours + 5.minutes)
       ]
     end
 
-    it "grants the first 5 users who completed the challenge respectively 5, 4, 3, 2 and 1 points" do
+    it "awards points to the first 5 users who completed the challenge" do
       expect(described_class.get).to include(
         { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
         { score: 4, user_id: 3, day: 1, challenge: 1, completion_id: completions[2].id },
@@ -61,7 +63,7 @@ RSpec.describe Scores::InsanityPoints do
       )
     end
 
-    it "grants 0 point to any other user who completed the challenge after the 5th" do
+    it "awards 0 points to users who completed the challenge after the 5th position" do
       expect(described_class.get).to include(
         { score: 0, user_id: 2, day: 1, challenge: 1, completion_id: completions[1].id },
         { score: 0, user_id: 4, day: 1, challenge: 1, completion_id: completions[3].id }
@@ -69,11 +71,9 @@ RSpec.describe Scores::InsanityPoints do
     end
 
     context "when there are non-insanity users" do
-      before do
-        user_5.update!(entered_hardcore: false)
-      end
+      before { user_5.update!(entered_hardcore: false) }
 
-      it "does not include them in the computation" do
+      it "excludes non-insanity users from the computation" do
         expect(described_class.get).to contain_exactly(
           { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
           { score: 4, user_id: 3, day: 1, challenge: 1, completion_id: completions[2].id },
@@ -86,21 +86,19 @@ RSpec.describe Scores::InsanityPoints do
     end
   end
 
-  describe "caching" do
-    it "creates cache records on first call" do
+  describe "caching behavior" do
+    it "creates cache records on the first call" do
       expect { described_class.get }.to change(Cache::InsanityPoint, :count).from(0).to(3)
     end
 
-    context "on second call" do
-      before do
-        described_class.get
-      end
+    context "on subsequent calls" do
+      before { described_class.get }
 
-      it "doesn't re-create cache" do
+      it "doesn't create new cache records" do
         expect { described_class.get }.not_to change(Cache::InsanityPoint, :count)
       end
 
-      it "doesn't do any computation" do
+      it "doesn't perform any computation" do
         expect_any_instance_of(described_class).not_to receive(:compute)
         described_class.get
       end

--- a/spec/domains/scores/insanity_points_spec.rb
+++ b/spec/domains/scores/insanity_points_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Scores::InsanityPoints do
     ]
   end
 
-  def create_completion(day, challenge, user, duration)
+  def create_completion(day:, challenge:, user:, duration:)
     completion_timestamp = Aoc.begin_time + (day - 1).days + duration
     create(:completion,
            day:,

--- a/spec/domains/scores/insanity_points_spec.rb
+++ b/spec/domains/scores/insanity_points_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe Scores::InsanityPoints do
 
   it "computes the points for users for each challenge" do
     expect(described_class.get).to contain_exactly(
-      { score: 2, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
-      { score: 2, user_id: 1, day: 1, challenge: 2, completion_id: completions[1].id },
-      { score: 1, user_id: 2, day: 1, challenge: 1, completion_id: completions[2].id }
+      { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
+      { score: 5, user_id: 1, day: 1, challenge: 2, completion_id: completions[1].id },
+      { score: 4, user_id: 2, day: 1, challenge: 1, completion_id: completions[2].id }
     )
   end
 
@@ -36,6 +36,8 @@ RSpec.describe Scores::InsanityPoints do
     let!(:user_3) { create(:user, id: 3, entered_hardcore: true) }
     let!(:user_4) { create(:user, id: 4, entered_hardcore: true) }
     let!(:user_5) { create(:user, id: 5, entered_hardcore: true) }
+    let!(:user_6) { create(:user, id: 6, entered_hardcore: true) }
+    let!(:user_7) { create(:user, id: 7, entered_hardcore: true) }
 
     let!(:completions) do
       [
@@ -43,22 +45,26 @@ RSpec.describe Scores::InsanityPoints do
         create_completion(1, 1, user_2, 1.day + 2.hours),
         create_completion(1, 1, user_3, 3.hours + 26.minutes),
         create_completion(1, 1, user_4, 3.days + 1.minute),
-        create_completion(1, 1, user_5, 4.hours)
+        create_completion(1, 1, user_5, 4.hours),
+        create_completion(1, 1, user_6, 4.hours + 3.minutes),
+        create_completion(1, 1, user_7, 4.hours + 5.minutes)
       ]
     end
 
-    it "gives the first user to complete the challenge as many points as there are players" do
+    it "grants the first 5 users who completed the challenge respectively 5, 4, 3, 2 and 1 points" do
       expect(described_class.get).to include(
-        { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id }
+        { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
+        { score: 4, user_id: 3, day: 1, challenge: 1, completion_id: completions[2].id },
+        { score: 3, user_id: 5, day: 1, challenge: 1, completion_id: completions[4].id },
+        { score: 2, user_id: 6, day: 1, challenge: 1, completion_id: completions[5].id },
+        { score: 1, user_id: 7, day: 1, challenge: 1, completion_id: completions[6].id }
       )
     end
 
-    it "gives each player one less point per player ahead of them" do
+    it "grants 0 point to any other user who completed the challenge after the 5th" do
       expect(described_class.get).to include(
-        { score: 4, user_id: 3, day: 1, challenge: 1, completion_id: completions[2].id },
-        { score: 3, user_id: 5, day: 1, challenge: 1, completion_id: completions[4].id },
-        { score: 2, user_id: 2, day: 1, challenge: 1, completion_id: completions[1].id },
-        { score: 1, user_id: 4, day: 1, challenge: 1, completion_id: completions[3].id }
+        { score: 0, user_id: 2, day: 1, challenge: 1, completion_id: completions[1].id },
+        { score: 0, user_id: 4, day: 1, challenge: 1, completion_id: completions[3].id }
       )
     end
 
@@ -69,10 +75,12 @@ RSpec.describe Scores::InsanityPoints do
 
       it "does not include them in the computation" do
         expect(described_class.get).to contain_exactly(
-          { score: 4, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
-          { score: 3, user_id: 3, day: 1, challenge: 1, completion_id: completions[2].id },
-          { score: 2, user_id: 2, day: 1, challenge: 1, completion_id: completions[1].id },
-          { score: 1, user_id: 4, day: 1, challenge: 1, completion_id: completions[3].id }
+          { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
+          { score: 4, user_id: 3, day: 1, challenge: 1, completion_id: completions[2].id },
+          { score: 3, user_id: 6, day: 1, challenge: 1, completion_id: completions[5].id },
+          { score: 2, user_id: 7, day: 1, challenge: 1, completion_id: completions[6].id },
+          { score: 1, user_id: 2, day: 1, challenge: 1, completion_id: completions[1].id },
+          { score: 0, user_id: 4, day: 1, challenge: 1, completion_id: completions[3].id }
         )
       end
     end


### PR DESCRIPTION
## Summary of changes and context

Closes #492 

Only the top 5 player of each challenge should be rewarded, respectively with 5, 4, 3, 2 and 1 point. Further completions do not grand points any more.

Thanks to the tests here, they were super helpful for the change :raised_hands: 

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
