### PR TITLE
Revamp the profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Upon Pull Request actions (open, push), CI scripts are automatically run tests, 
 
 ### Required `ENV` variables
 
-> **Warning**
-The `.env` file is used for development purposes only. It is _not_ versioned and never should.
+> [!CAUTION]
+> The `.env` file is used for development purposes only. It is _not_ versioned and never should.
 
 - `AOC_ROOMS` is a comma-separated list of [private leaderboard](https://adventofcode.com/leaderboard/private) IDs that _you belong_ to (e.g. `9999999-a0b1c2d3,7777777-e4f56789`)
 - `SESSION_COOKIE` is your own Advent of Code session cookie (valid ~ 1 month). You need to [log in](https://adventofcode.com/auth/login) to the platform, then retrieve the value of the `session` cookie (e.g. `436088a9...9ffb6476`)
 
 ### Overmind (optional)
 
-> **Note**
+> [!NOTE]
 > Foreman is the default process manager through the `bin/dev` command. Overmind is an optional alternative.
 
 Overmind is a process manager for Procfile-based applications like ours, based on `tmux`. You can install the tool on your machine [following these instructions](https://github.com/DarthSim/overmind#installation).
@@ -55,15 +55,23 @@ Then, instead of the usual `bin/dev`, you have to run `overmind s`.
 
 In short: create an SSL certificate for your localhost, store it in your keychain and run the server using that certificate.
 
+On macOS:
 ```zsh
 mkcert localhost
-sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ./localhost.pem # macOS-specific
-mv localhost* tmp/ # this is the tmp folder in the project root
-bin/dev ssl
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ./localhost.pem
 ```
 
-> **Note**
-> Tested on macOS only.
+On Ubuntu:
+```zsh
+sudo apt install openssl
+openssl req -x509 -newkey rsa:2048 -nodes -keyout localhost-key.pem -out localhost.pem -days 365 -subj "/C=FR/ST=State/L=Locality/O=Organization/CN=localhost"
+```
+
+Finally, move the generated files to the `tmp` folder in the project root and start the server with `bin/dev ssl`.
+```zsh
+mv localhost* tmp/
+bin/dev ssl
+```     
 
 ## Launch the webapp on local mobile browser
 
@@ -74,7 +82,7 @@ sign_in(User.find_by(github_username: "your_username"))
 
 Then, find the local IP address of the computer you launch the server from (ex: `192.168.1.14`) and open the app on your mobile browser from that IP (ex: `http://192.168.1.14:3000`)
 
-> **Warning**
+> [!CAUTION]
 > Bypassing authentication, even temporarily, can pose significant security risks. Only use this method in a controlled development environment and never in production.
 
 # Advent of Code API

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,14 +5,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find_by!(uid: params[:uid])
-
-    if @user.squad_id.present?
-      squad_scores = Scores::SquadScores.get
-      squad_presenter = Scores::SquadScoresPresenter.new(squad_scores)
-      squads = squad_presenter.get
-      @squad_stats = squads.find { |h| h[:id] == @user.squad_id }
-    end
-
+    @user_squad = @user.squad
     @latest_day = Aoc.latest_day
 
     user_completions = Scores::InsanityPoints.get.select { |completion| completion[:user_id] == @user.id }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,11 +6,6 @@ class UsersController < ApplicationController
   def show
     @user = User.find_by!(uid: params[:uid])
 
-    insanity_scores = Scores::InsanityScores.get
-    insanity_presenter = Scores::UserScoresPresenter.new(insanity_scores)
-    insane_participants = insanity_presenter.get
-    @insanity_stats = insane_participants.find { |h| h[:uid].to_s == @user.uid }
-
     if @user.squad_id.present?
       squad_scores = Scores::SquadScores.get
       squad_presenter = Scores::SquadScoresPresenter.new(squad_scores)
@@ -19,11 +14,16 @@ class UsersController < ApplicationController
     end
 
     @latest_day = Aoc.latest_day
-    @daily_completions = Array.new(@latest_day) { [nil, nil] }
 
-    Completion.where(user: @user).find_each do |completion|
-      @daily_completions[@latest_day - completion.day][completion.challenge - 1] = completion
+    user_completions = Scores::InsanityPoints.get.select { |completion| completion[:user_id] == @user.id }
+
+    @daily_completions = Array.new(@latest_day) { [nil, nil] }
+    user_completions.each do |completion|
+      @daily_completions[@latest_day - completion[:day]][completion[:challenge] - 1] = completion
     end
+
+    @silver_stars = @daily_completions.count { |day| day[0] && !day[1] }
+    @gold_stars = @daily_completions.count { |day| day[1] }
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,10 +6,12 @@ class UsersController < ApplicationController
   def show
     @user = User.find_by!(uid: params[:uid])
 
-    squad_scores = Scores::SquadScores.get
-    squad_presenter = Scores::SquadScoresPresenter.new(squad_scores)
-    squads = squad_presenter.get
-    @squad_stats = squads.find { |h| h[:id] == @user.squad_id }
+    if @user.squad_id.present?
+      squad_scores = Scores::SquadScores.get
+      squad_presenter = Scores::SquadScoresPresenter.new(squad_scores)
+      squads = squad_presenter.get
+      @squad_stats = squads.find { |h| h[:id] == @user.squad_id }
+    end
 
     @latest_day = Aoc.latest_day
     @daily_completions = Array.new(@latest_day) { [nil, nil] }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,11 +6,6 @@ class UsersController < ApplicationController
   def show
     @user = User.find_by!(uid: params[:uid])
 
-    casual_scores = Scores::SoloScores.get
-    casual_presenter = Scores::UserScoresPresenter.new(casual_scores)
-    casual_participants = casual_presenter.get
-    @casual_stats = casual_participants.find { |h| h[:uid].to_s == @user.uid }
-
     insanity_scores = Scores::InsanityScores.get
     insanity_presenter = Scores::UserScoresPresenter.new(insanity_scores)
     insane_participants = insanity_presenter.get
@@ -20,16 +15,6 @@ class UsersController < ApplicationController
     squad_presenter = Scores::SquadScoresPresenter.new(squad_scores)
     squads = squad_presenter.get
     @squad_stats = squads.find { |h| h[:id] == @user.squad_id }
-
-    city_scores = Scores::CityScores.get
-    city_presenter = Scores::CityScoresPresenter.new(city_scores)
-    cities = city_presenter.get
-    @campus_stats = cities.find { |h| h[:id] == @user.city_id }
-
-    # Sort user achievements in the same order as in the YAML definition
-    @achievements = @user.achievements
-                         .pluck(:nature)
-                         .sort_by { |nature| Achievement.keys.index(nature.to_sym) }
 
     @latest_day = Aoc.latest_day
     @daily_completions = Array.new(@latest_day) { [nil, nil] }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,10 @@ class UsersController < ApplicationController
   def show
     @user = User.find_by!(uid: params[:uid])
 
+    completions = @user.completions.group_by(&:challenge).transform_values(&:count)
+    @gold_stars = completions[2] || 0
+    @silver_stars = (completions[1] || 0) - @gold_stars
+
     if @user.squad_id.present?
       squad_scores = Scores::SquadScores.get
       squad_presenter = Scores::SquadScoresPresenter.new(squad_scores)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,9 +6,10 @@ class UsersController < ApplicationController
   def show
     @user = User.find_by!(uid: params[:uid])
 
-    completions = @user.completions.group_by(&:challenge).transform_values(&:count)
-    @gold_stars = completions[2] || 0
-    @silver_stars = (completions[1] || 0) - @gold_stars
+    insanity_scores = Scores::InsanityScores.get
+    insanity_presenter = Scores::UserScoresPresenter.new(insanity_scores)
+    insane_participants = insanity_presenter.get
+    @insanity_stats = insane_participants.find { |h| h[:uid].to_s == @user.uid }
 
     if @user.squad_id.present?
       squad_scores = Scores::SquadScores.get

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,11 +6,6 @@ class UsersController < ApplicationController
   def show
     @user = User.find_by!(uid: params[:uid])
 
-    insanity_scores = Scores::InsanityScores.get
-    insanity_presenter = Scores::UserScoresPresenter.new(insanity_scores)
-    insane_participants = insanity_presenter.get
-    @insanity_stats = insane_participants.find { |h| h[:uid].to_s == @user.uid }
-
     squad_scores = Scores::SquadScores.get
     squad_presenter = Scores::SquadScoresPresenter.new(squad_scores)
     squads = squad_presenter.get

--- a/app/domains/scores/insanity_points.rb
+++ b/app/domains/scores/insanity_points.rb
@@ -28,7 +28,7 @@ module Scores
 
       completions.map do |completion|
         completion.attributes.symbolize_keys
-                  .slice(:score, :user_id, :day, :challenge)
+                  .slice(:score, :user_id, :day, :challenge, :duration)
                   .merge(completion_id: completion.id)
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   encrypts :slack_access_token
 
   ADMINS = { pilou: "6788", aquaj: "449" }.freeze
-  CONTRIBUTORS = { pilou: "6788", aquaj: "449", louis: "19049", aurelie: "9168" }.freeze
+  CONTRIBUTORS = { pilou: "6788", aquaj: "449", louis: "19049" }.freeze
 
   belongs_to :batch, optional: true
   belongs_to :city, optional: true, touch: true

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,35 +1,47 @@
-<div class="text-lg flex flex-wrap flex-col sm:flex-row items-center sm:justify-between">
-  <div class="flex flex-wrap gap-x-6">
-    <h2 class="strong"><%= @user.username %></h2>
+<div class="my-4 flex flex-col gap-y-2">
+  <div class="text-xl flex justify-between">
+    <div class="flex flex-wrap gap-x-6">
+      <h2 class="strong"><%= @user.username %></h2>
 
-    <% if @user.batch_id.present? %>
-      <span>·</span>
-      <span>batch #<%= @user.batch.number %></span>
-    <% end %>
+      <% if @user.slack_id.present? %>
+        <span>·</span>
+        <%= link_to "@#{@user.slack_username}", @user.slack_link, target: :_blank, rel: :noopener, class: "link-explicit link-slack" %>
+      <% end %>
 
-    <span>·</span>
-    <span><%= @user.city.vanity_name %></span>
+      <% if @user.favourite_language.present? %>
+        <span>·</span>
+        <%= image_tag "languages/#{@user.favourite_language}.png", class: "h-6 self-center transition-all opacity-80" %>
+      <% end %>
+    </div>
+
+    <div class="flex flex-wrap gap-x-6">
+      <span>
+        <% if @silver_stars > 0 %>
+          <span class="text-aoc-silver"><%= @silver_stars %>*</span>
+        <% end %>
+        <span class="text-aoc-gold"><%= @gold_stars %>*</span>
+      </span>
+    </div>
   </div>
-</div>
 
-<div class="my-4 flex flex-wrap justify-center gap-2">
-  <% if @squad_stats.present? %>
-    <%= link_to squad_path(@squad_stats[:id]), class: "w-36 h-36 p-2 flex flex-col justify-between border border-aoc-gray-darker bg-aoc-gray-darkest hover:bg-aoc-gray-darker" do %>
-      <h3 class="h-2/5 flex items-center justify-center strong text-center text-lg">
-        <%= @squad_stats[:name] %>
-      </h3>
+  <div class="flex justify-between">
+    <div class="flex flex-wrap gap-x-6">
+      <% if @user.batch_id.present? %>
+        <span>#<%= @user.batch.number %></span>
+        <span>·</span>
+      <% end %>
 
-      <div class="h-3/5 flex flex-col justify-around">
-        <span class="flex items-center justify-center text-aoc-atmospheric text-lg">
-          <%= @squad_stats[:score] %> pts
-        </span>
+      <span><%= @user.city.vanity_name %></span>
+    </div>
 
-        <span class="flex items-center justify-center text-lg">
-          <%= @squad_stats[:rank] %><sup><%= @squad_stats[:rank].ordinal %></sup>
-        </span>
-      </div>
-    <% end %>
-  <% end %>
+    <div class="flex flex-wrap gap-x-6">
+      <% if @squad_stats.present? %>
+        <%= link_to squad_path(@squad_stats[:id]), class: "link-explicit" do %>
+          <%= @squad_stats[:name] %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>
 
 <div class="my-4 pb-2 block overflow-x-auto max-w-full">
@@ -49,21 +61,13 @@
     <% @daily_completions.each_with_index do |completion, day| %>
       <tr>
         <th class="font-light"><%= @latest_day - day %></th>
-
-        <% if completion[0] %>
-          <td><%= duration_as_text(completion[0].duration) %></td>
-          <td><%= "" %></td>
-        <% else %>
-          <td>-</td>
-          <td>-</td>
-        <% end %>
-
-        <% if completion[1] %>
-          <td><%= duration_as_text(completion[1].duration) %></td>
-          <td><%= "" %></td>
-        <% else %>
-          <td>-</td>
-          <td>-</td>
+        <% [0, 1].each do |part| %>
+          <% if completion[part] %>
+            <td><%= duration_as_text(completion[part].duration) %></td>
+            <td></td>
+          <% else %>
+            <td colspan="2">-</td>
+          <% end %>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,14 +16,10 @@
 
     <div class="flex flex-wrap gap-x-6">
       <span>
-        <% if @insanity_stats.present? %>
-          <% if @insanity_stats[:silver_stars] > 0 %>
-            <span class="text-aoc-silver"><%= @insanity_stats[:silver_stars] %>*</span>
-          <% end %>
-          <span class="text-aoc-gold"><%= @insanity_stats[:gold_stars] %>*</span>
-        <% else %>
-          <span class="text-aoc-gold">0*</span>
+        <% if @silver_stars > 0 %>
+          <span class="text-aoc-silver"><%= @silver_stars %>*</span>
         <% end %>
+        <span class="text-aoc-gold"><%= @gold_stars %>*</span>
       </span>
     </div>
   </div>
@@ -67,8 +63,8 @@
         <th class="font-light"><%= @latest_day - day %></th>
         <% [0, 1].each do |part| %>
           <% if completion[part] %>
-            <td><%= duration_as_text(completion[part].duration) %></td>
-            <td></td>
+            <td><%= duration_as_text(completion[part][:duration]) %></td>
+            <td><%= completion[part][:score] %></td>
           <% else %>
             <td colspan="2">-</td>
           <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,21 +4,8 @@
 
     <% if @user.batch_id.present? %>
       <span>·</span>
-      <span>batch #<%= @user.batch.number %></span>
+      <span>batch #<%= @user.batch.number %> (<%= @user.city.vanity_name %>)</span>
     <% end %>
-  </div>
-
-  <div class="flex gap-x-6">
-    <span>
-      <% if @casual_stats[:silver_stars] > 0 %>
-        <span class="text-aoc-silver"><%= @casual_stats[:silver_stars] %>*</span>
-      <% end %>
-      <span class="text-aoc-gold"><%= @casual_stats[:gold_stars] %>*</span>
-    </span>
-    <span>·</span>
-    <span class="text-aoc-atmospheric"><%= @casual_stats[:score] %> pts</span>
-    <span>·</span>
-    <span><%= @casual_stats[:rank] %><sup><%= @casual_stats[:rank].ordinal %></sup></span>
   </div>
 </div>
 
@@ -58,35 +45,7 @@
       </div>
     <% end %>
   <% end %>
-
-  <% if @campus_stats.present? %>
-    <%= link_to campus_path(@campus_stats[:slug]), class: "w-36 h-36 p-2 flex flex-col justify-between border border-aoc-gray-darker bg-aoc-gray-darkest hover:bg-aoc-gray-darker" do %>
-      <h3 class="h-2/5 flex items-center justify-center strong text-center text-lg">
-        <%= @campus_stats[:vanity_name] %>
-      </h3>
-
-      <div class="h-3/5 flex flex-col justify-around">
-        <span class="flex items-center justify-center text-aoc-atmospheric text-lg">
-          <%= @campus_stats[:score] %> pts
-        </span>
-
-        <span class="flex items-center justify-center text-lg">
-          <%= @campus_stats[:rank] %><sup><%= @campus_stats[:rank].ordinal %></sup>
-        </span>
-      </div>
-    <% end %>
-  <% end %>
 </div>
-
-<h3 class="text-center">Achievements unlocked: <span class="strong"><%= @achievements.count %></span>/<%= Achievement.total %></h3>
-
-<% if @achievements.any? %>
-
-<div class="my-4 flex flex-wrap gap-x-6 justify-center">
-  <%= render Achievements::UnlockedComponent.with_collection(@achievements) %>
-</div>
-
-<% end %>
 
 <div class="my-4 pb-2 block overflow-x-auto max-w-full">
   <table class="w-[30rem] mx-auto text-right leading-tight">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,8 +4,11 @@
 
     <% if @user.batch_id.present? %>
       <span>·</span>
-      <span>batch #<%= @user.batch.number %> (<%= @user.city.vanity_name %>)</span>
+      <span>batch #<%= @user.batch.number %></span>
     <% end %>
+
+    <span>·</span>
+    <span><%= @user.city.vanity_name %></span>
   </div>
 </div>
 
@@ -30,19 +33,17 @@
 </div>
 
 <div class="my-4 pb-2 block overflow-x-auto max-w-full">
-  <table class="w-[30rem] mx-auto text-right leading-tight">
+  <table class="mx-auto text-right leading-tight">
     <tr>
       <th rowspan="2" class="align-bottom font-light">Day</th>
-      <th colspan="3" class="font-light text-aoc-silver">----- Part 1 -----</th>
-      <th colspan="3" class="font-light text-aoc-gold">----- Part 2 -----</th>
+      <th colspan="2" class="font-light text-aoc-silver">- Part 1 -</th>
+      <th colspan="2" class="font-light text-aoc-gold">- Part 2 -</th>
     </tr>
     <tr>
-      <th class="w-24 font-light text-aoc-silver">Time</th>
-      <th class="w-16 font-light text-aoc-silver">Rank</th>
-      <th class="w-16 font-light text-aoc-silver">Score</th>
-      <th class="w-24 font-light text-aoc-gold">Time</th>
-      <th class="w-16 font-light text-aoc-gold">Rank</th>
-      <th class="w-16 font-light text-aoc-gold">Score</th>
+      <th class="w-24 font-light">Time</th>
+      <th class="w-16 font-light">Score</th>
+      <th class="w-24 font-light">Time</th>
+      <th class="w-16 font-light">Score</th>
     </tr>
 
     <% @daily_completions.each_with_index do |completion, day| %>
@@ -52,9 +53,7 @@
         <% if completion[0] %>
           <td><%= duration_as_text(completion[0].duration) %></td>
           <td><%= "" %></td>
-          <td><%= "" %></td>
         <% else %>
-          <td>-</td>
           <td>-</td>
           <td>-</td>
         <% end %>
@@ -62,9 +61,7 @@
         <% if completion[1] %>
           <td><%= duration_as_text(completion[1].duration) %></td>
           <td><%= "" %></td>
-          <td><%= "" %></td>
         <% else %>
-          <td>-</td>
           <td>-</td>
           <td>-</td>
         <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,9 +35,9 @@
     </div>
 
     <div class="flex flex-wrap gap-x-6">
-      <% if @squad_stats.present? %>
-        <%= link_to squad_path(@squad_stats[:id]), class: "link-explicit" do %>
-          <%= @squad_stats[:name] %>
+      <% if @user_squad.present? %>
+        <%= link_to squad_path(@user_squad.id), class: "link-explicit" do %>
+          <%= @user_squad.name %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,10 +16,14 @@
 
     <div class="flex flex-wrap gap-x-6">
       <span>
-        <% if @silver_stars > 0 %>
-          <span class="text-aoc-silver"><%= @silver_stars %>*</span>
+        <% if @insanity_stats.present? %>
+          <% if @insanity_stats[:silver_stars] > 0 %>
+            <span class="text-aoc-silver"><%= @insanity_stats[:silver_stars] %>*</span>
+          <% end %>
+          <span class="text-aoc-gold"><%= @insanity_stats[:gold_stars] %>*</span>
+        <% else %>
+          <span class="text-aoc-gold">0*</span>
         <% end %>
-        <span class="text-aoc-gold"><%= @gold_stars %>*</span>
       </span>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,24 +10,6 @@
 </div>
 
 <div class="my-4 flex flex-wrap justify-center gap-2">
-  <% if @user.entered_hardcore? %>
-    <div class="w-36 h-36 p-2 flex flex-col justify-between border border-aoc-gray-darker bg-aoc-gray-darker">
-      <h3 class="h-2/5 flex items-center justify-center strong text-center text-lg">
-        insanity
-      </h3>
-
-      <div class="h-3/5 flex flex-col justify-around">
-        <span class="flex items-center justify-center text-aoc-atmospheric text-lg">
-          <%= @insanity_stats[:score] %> pts
-        </span>
-
-        <span class="flex items-center justify-center text-lg">
-          <%= @insanity_stats[:rank] %><sup><%= @insanity_stats[:rank].ordinal %></sup>
-        </span>
-      </div>
-    </div>
-  <% end %>
-
   <% if @squad_stats.present? %>
     <%= link_to squad_path(@squad_stats[:id]), class: "w-36 h-36 p-2 flex flex-col justify-between border border-aoc-gray-darker bg-aoc-gray-darkest hover:bg-aoc-gray-darker" do %>
       <h3 class="h-2/5 flex items-center justify-center strong text-center text-lg">

--- a/db/migrate/20241002165818_add_duration_to_insanity_points.rb
+++ b/db/migrate/20241002165818_add_duration_to_insanity_points.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDurationToInsanityPoints < ActiveRecord::Migration[7.1]
+  def change
+    add_column :insanity_points, :duration, :interval
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_20_164719) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_02_165818) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -245,6 +245,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_164719) do
     t.bigint "completion_id"
     t.datetime "created_at", null: false
     t.integer "day"
+    t.interval "duration"
     t.integer "score"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false

--- a/spec/domains/scores/insanity_points_spec.rb
+++ b/spec/domains/scores/insanity_points_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe Scores::InsanityPoints do
   describe "#get" do
     it "computes the points for users for each challenge" do
       expect(described_class.get).to contain_exactly(
-        { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
-        { score: 5, user_id: 1, day: 1, challenge: 2, completion_id: completions[1].id },
-        { score: 4, user_id: 2, day: 1, challenge: 1, completion_id: completions[2].id }
+        { score: 5, user_id: 1, day: 1, challenge: 1, duration: 3.hours + 25.minutes, completion_id: completions[0].id },
+        { score: 5, user_id: 1, day: 1, challenge: 2, duration: 1.day + 12.minutes, completion_id: completions[1].id },
+        { score: 4, user_id: 2, day: 1, challenge: 1, duration: 3.days + 1.minute, completion_id: completions[2].id }
       )
     end
   end
@@ -55,18 +55,18 @@ RSpec.describe Scores::InsanityPoints do
 
     it "awards points to the first 5 users who completed the challenge" do
       expect(described_class.get).to include(
-        { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
-        { score: 4, user_id: 3, day: 1, challenge: 1, completion_id: completions[2].id },
-        { score: 3, user_id: 5, day: 1, challenge: 1, completion_id: completions[4].id },
-        { score: 2, user_id: 6, day: 1, challenge: 1, completion_id: completions[5].id },
-        { score: 1, user_id: 7, day: 1, challenge: 1, completion_id: completions[6].id }
+        { score: 5, user_id: 1, day: 1, challenge: 1, duration: 3.hours + 25.minutes, completion_id: completions[0].id },
+        { score: 4, user_id: 3, day: 1, challenge: 1, duration: 3.hours + 26.minutes, completion_id: completions[2].id },
+        { score: 3, user_id: 5, day: 1, challenge: 1, duration: 4.hours, completion_id: completions[4].id },
+        { score: 2, user_id: 6, day: 1, challenge: 1, duration: 4.hours + 3.minutes, completion_id: completions[5].id },
+        { score: 1, user_id: 7, day: 1, challenge: 1, duration: 4.hours + 5.minutes, completion_id: completions[6].id }
       )
     end
 
     it "awards 0 points to users who completed the challenge after the 5th position" do
       expect(described_class.get).to include(
-        { score: 0, user_id: 2, day: 1, challenge: 1, completion_id: completions[1].id },
-        { score: 0, user_id: 4, day: 1, challenge: 1, completion_id: completions[3].id }
+        { score: 0, user_id: 2, day: 1, challenge: 1, duration: 1.day + 2.hours, completion_id: completions[1].id },
+        { score: 0, user_id: 4, day: 1, challenge: 1, duration: 3.days + 1.minute, completion_id: completions[3].id }
       )
     end
 
@@ -75,12 +75,12 @@ RSpec.describe Scores::InsanityPoints do
 
       it "excludes non-insanity users from the computation" do
         expect(described_class.get).to contain_exactly(
-          { score: 5, user_id: 1, day: 1, challenge: 1, completion_id: completions[0].id },
-          { score: 4, user_id: 3, day: 1, challenge: 1, completion_id: completions[2].id },
-          { score: 3, user_id: 6, day: 1, challenge: 1, completion_id: completions[5].id },
-          { score: 2, user_id: 7, day: 1, challenge: 1, completion_id: completions[6].id },
-          { score: 1, user_id: 2, day: 1, challenge: 1, completion_id: completions[1].id },
-          { score: 0, user_id: 4, day: 1, challenge: 1, completion_id: completions[3].id }
+          { score: 5, user_id: 1, day: 1, challenge: 1, duration: 3.hours + 25.minutes, completion_id: completions[0].id },
+          { score: 4, user_id: 3, day: 1, challenge: 1, duration: 3.hours + 26.minutes, completion_id: completions[2].id },
+          { score: 3, user_id: 6, day: 1, challenge: 1, duration: 4.hours + 3.minutes, completion_id: completions[5].id },
+          { score: 2, user_id: 7, day: 1, challenge: 1, duration: 4.hours + 5.minutes, completion_id: completions[6].id },
+          { score: 1, user_id: 2, day: 1, challenge: 1, duration: 1.day + 2.hours, completion_id: completions[1].id },
+          { score: 0, user_id: 4, day: 1, challenge: 1, duration: 3.days + 1.minute, completion_id: completions[3].id }
         )
       end
     end


### PR DESCRIPTION
## Summary of changes and context

Closes #503 
Closes #504 
Closes #505 
Closes #498 

* Remove all scores and ranks from the profile page (campus, squad, solo), except for the Insanity daily scores
* Remove the achievements section
* The `Score` column in the time tables now corresponds to the (new) insanity score
* Add the link to Slack profile, the favourite programming language
* Add the steps to add SSL certificate on Ubuntu in the README

Before
![Screenshot from 2024-10-02 19-31-00](https://github.com/user-attachments/assets/649b1581-dd07-4f96-a51a-0223b6d72d2d)
After
![Screenshot from 2024-10-02 19-31-09](https://github.com/user-attachments/assets/85f64c4d-f781-4306-914c-20bbe7ab4d4e)

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
