### PR TITLE
Restore all users insanity

### DIFF
--- a/app/domains/ranks/insanity_scores.rb
+++ b/app/domains/ranks/insanity_scores.rb
@@ -12,7 +12,9 @@ module Ranks
       completions = @completions.fetch(score[:user_id], [])
       [
         score[:score],
-        -completions.sum(&:duration)
+        completions.count,
+        -completions.sum { |completion| completion.duration || 0 },
+        -score[:user_id]
       ]
     end
   end

--- a/app/domains/scores/insanity_scores.rb
+++ b/app/domains/scores/insanity_scores.rb
@@ -25,12 +25,12 @@ module Scores
       points
         .group_by { |p| p[:user_id] }
         .reverse_merge(default_points)
-        .filter_map do |user_id, user_points|
+        .map do |user_id, user_points|
           total_score = user_points.sum { |point| point[:score] }
           day_score = user_points.select { |point| point[:day] == Aoc.latest_day }
                                  .sum { |point| point[:score] }
 
-          { user_id:, score: total_score, current_day_score: day_score } if total_score > 0
+          { user_id:, score: total_score, current_day_score: day_score }
         end
     end
   end

--- a/spec/domains/ranks/insanity_scores_spec.rb
+++ b/spec/domains/ranks/insanity_scores_spec.rb
@@ -14,9 +14,6 @@ RSpec.describe Ranks::InsanityScores do
     ]
   end
 
-  # Use a fixed time in the future to ensure positive durations
-  let(:fake_now) { Time.new(2100, 1, 1, 0, 0, 0, Aoc.event_timezone) }
-
   it_behaves_like "a ranker"
 
   it "sorts by score" do
@@ -51,9 +48,11 @@ RSpec.describe Ranks::InsanityScores do
 
     context "and users have completed the same puzzles, but took different times to complete them" do
       it "prioritizes by smaller total duration of puzzle solving" do
-        create(:completion, user: pilou, day: 1, completion_unix_time: fake_now + 40.hours)
-        create(:completion, user: aquaj, day: 1, completion_unix_time: fake_now + 20.hours)
-        create(:completion, user: foo, day: 1, completion_unix_time: fake_now + 30.hours)
+        travel_to Time.new(2030, 12, 1, 0, 0, 0, Aoc.event_timezone)
+
+        create(:completion, user: pilou, day: 1, completion_unix_time: 40.hours.from_now)
+        create(:completion, user: aquaj, day: 1, completion_unix_time: 20.hours.from_now)
+        create(:completion, user: foo, day: 1, completion_unix_time: 30.hours.from_now)
 
         expect(described_class.new(input).rank).to eq([
                                                         input[1],
@@ -65,9 +64,11 @@ RSpec.describe Ranks::InsanityScores do
 
     context "and users have completed the same puzzles, took the same time to complete them" do
       it "prioritizes by user id" do
-        create(:completion, user: pilou, day: 1, completion_unix_time: fake_now + 2.hours)
-        create(:completion, user: aquaj, day: 1, completion_unix_time: fake_now + 2.hours)
-        create(:completion, user: foo, day: 1, completion_unix_time: fake_now + 2.hours)
+        travel_to Time.new(2030, 12, 1, 0, 0, 0, Aoc.event_timezone)
+
+        create(:completion, user: pilou, day: 1, completion_unix_time: 2.hours.from_now)
+        create(:completion, user: aquaj, day: 1, completion_unix_time: 2.hours.from_now)
+        create(:completion, user: foo, day: 1, completion_unix_time: 2.hours.from_now)
 
         expect(described_class.new(input).rank).to eq([
                                                         input[0],

--- a/spec/domains/ranks/insanity_scores_spec.rb
+++ b/spec/domains/ranks/insanity_scores_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe Ranks::InsanityScores do
       end
     end
 
-    context "and users have completed the same number of puzzles, but took different times to complete them" do
+    context "and users have completed the same puzzles, but took different times to complete them" do
       it "prioritizes by smaller total duration of puzzle solving" do
-        create(:completion, user: pilou, completion_unix_time: fake_now + 40.hours)
-        create(:completion, user: aquaj, completion_unix_time: fake_now + 20.hours)
-        create(:completion, user: foo, completion_unix_time: fake_now + 30.hours)
+        create(:completion, user: pilou, day: 1, completion_unix_time: fake_now + 40.hours)
+        create(:completion, user: aquaj, day: 1, completion_unix_time: fake_now + 20.hours)
+        create(:completion, user: foo, day: 1, completion_unix_time: fake_now + 30.hours)
 
         expect(described_class.new(input).rank).to eq([
                                                         input[1],
@@ -63,11 +63,11 @@ RSpec.describe Ranks::InsanityScores do
       end
     end
 
-    context "and users have completed the same number of puzzles, took the same time to complete them" do
+    context "and users have completed the same puzzles, took the same time to complete them" do
       it "prioritizes by user id" do
-        create(:completion, user: pilou, completion_unix_time: fake_now + 2.hours)
-        create(:completion, user: aquaj, completion_unix_time: fake_now + 2.hours)
-        create(:completion, user: foo, completion_unix_time: fake_now + 2.hours)
+        create(:completion, user: pilou, day: 1, completion_unix_time: fake_now + 2.hours)
+        create(:completion, user: aquaj, day: 1, completion_unix_time: fake_now + 2.hours)
+        create(:completion, user: foo, day: 1, completion_unix_time: fake_now + 2.hours)
 
         expect(described_class.new(input).rank).to eq([
                                                         input[0],

--- a/spec/domains/ranks/insanity_scores_spec.rb
+++ b/spec/domains/ranks/insanity_scores_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Ranks::InsanityScores do
-  let(:pilou) { create :user, username: "Pil0u" }
-  let(:aquaj) { create :user, username: "Aquaj" }
+  let(:pilou) { create :user, id: 1, username: "Pil0u" }
+  let(:aquaj) { create :user, id: 2, username: "Aquaj" }
+  let(:foo) { create :user, id: 3, username: "Foo" }
 
   let(:input) do
     [
@@ -12,6 +13,9 @@ RSpec.describe Ranks::InsanityScores do
       { score: 50, user_id: aquaj.id }
     ]
   end
+
+  # Use a fixed time in the future to ensure positive durations
+  let(:fake_now) { Time.new(2100, 1, 1, 0, 0, 0, Aoc.event_timezone) }
 
   it_behaves_like "a ranker"
 
@@ -22,26 +26,55 @@ RSpec.describe Ranks::InsanityScores do
                                                      ])
   end
 
-  describe "tie-breaking" do
+  describe "when scores are tied" do
     let(:input) do
       [
         { score: 50, user_id: pilou.id },
-        { score: 50, user_id: aquaj.id }
+        { score: 50, user_id: aquaj.id },
+        { score: 50, user_id: foo.id }
       ]
     end
 
-    let!(:completions) do
-      [
-        create(:completion, user: aquaj, day: 1, completion_unix_time: Aoc.begin_time + 20.hours),
-        create(:completion, user: pilou, day: 1, completion_unix_time: Aoc.begin_time + 10.hours)
-      ]
+    context "and users have completed different numbers of puzzles" do
+      it "the more completed puzzles the better" do
+        create_list(:completion, 2, user: pilou)
+        create_list(:completion, 3, user: aquaj)
+        create_list(:completion, 1, user: foo)
+
+        expect(described_class.new(input).rank).to eq([
+                                                        input[1],
+                                                        input[0],
+                                                        input[2]
+                                                      ])
+      end
     end
 
-    it "prioritizes shorter completion times" do
-      expect(described_class.new(input).rank).to match([
-                                                         input[0],
-                                                         input[1]
-                                                       ])
+    context "and users have completed the same number of puzzles, but took different times to complete them" do
+      it "prioritizes by smaller total duration of puzzle solving" do
+        create(:completion, user: pilou, completion_unix_time: fake_now + 40.hours)
+        create(:completion, user: aquaj, completion_unix_time: fake_now + 20.hours)
+        create(:completion, user: foo, completion_unix_time: fake_now + 30.hours)
+
+        expect(described_class.new(input).rank).to eq([
+                                                        input[1],
+                                                        input[2],
+                                                        input[0]
+                                                      ])
+      end
+    end
+
+    context "and users have completed the same number of puzzles, took the same time to complete them" do
+      it "prioritizes by user id" do
+        create(:completion, user: pilou, completion_unix_time: fake_now + 2.hours)
+        create(:completion, user: aquaj, completion_unix_time: fake_now + 2.hours)
+        create(:completion, user: foo, completion_unix_time: fake_now + 2.hours)
+
+        expect(described_class.new(input).rank).to eq([
+                                                        input[0],
+                                                        input[1],
+                                                        input[2]
+                                                      ])
+      end
     end
   end
 end

--- a/spec/domains/scores/insanity_scores_spec.rb
+++ b/spec/domains/scores/insanity_scores_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Scores::InsanityScores do
   context "when a user has no points" do
     let!(:user_3) { create(:user, id: 3, entered_hardcore: true) }
 
-    it "excludes them" do
-      expect(described_class.get).not_to include(
+    it "includes them, with 0 points" do
+      expect(described_class.get).to include(
         hash_including(score: 0, user_id: 3)
       )
     end


### PR DESCRIPTION
## Summary of changes and context

- Closes #600

* Display all users, even the ones with a score of 0
* Order them with new tie breakers: higher score, higher number of completions, lower total time to solve puzzles, lower user ID -> even with a score of 0 for the Ladder of insanity, people will be shadowingly ordered based on these

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
