### PR TITLE
Fix the clipboard Stimulus controller

### DIFF
--- a/app/views/pages/patrons.html.erb
+++ b/app/views/pages/patrons.html.erb
@@ -6,21 +6,19 @@
   </p>
   <p>
     You can become one, by sharing your personal referral code
-    <span class="relative inline-block" data-controller="clipboard">
-      <code class="copyable"
-            data-action="click->clipboard#copy"
-            data-clipboard-content-value="<%= current_user.referral_code %>"><%= current_user.referral_code %></code>
+    <span data-controller="clipboard"
+          data-clipboard-content-value="<%= current_user.referral_code %>"
+          class="relative inline-block">
+      <code data-action="click->clipboard#copy" class="copyable"><%= current_user.referral_code %></code>
       <span data-clipboard-target="feedback" class="hidden absolute -top-4 right-0 text-xs">Copied!</span>
     </span>
     or URL (click to copy)
   </p>
 
-  <div class="relative w-max mx-auto" data-controller="clipboard">
-    <code class="copyable"
-          data-action="click->clipboard#copy"
-          data-clipboard-content-value="<%= current_user.referral_link(request) %>">
-      <%= current_user.referral_link(request) %>
-    </code>
+  <div data-controller="clipboard"
+       data-clipboard-content-value="<%= current_user.referral_link(request) %>"
+       class="relative w-max mx-auto">
+    <code data-action="click->clipboard#copy" class="copyable"><%= current_user.referral_link(request) %></code>
     <span data-clipboard-target="feedback" class="hidden absolute -top-4 right-0 text-xs">Copied!</span>
   </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -112,7 +112,7 @@
 
         <div data-controller="clipboard"
              data-clipboard-content-value="<%= @account_squad.pin %>"
-             class="flex flex-col gap-y-1 sm:flex-row sm:items-center sm:gap-x-3 relative" >
+             class="flex flex-col gap-y-1 sm:flex-row sm:items-center sm:gap-x-3 relative">
           <span>PIN:</span>
           <code class="w-48 text-center tracking-[0.5rem] copyable"
                 data-action="click->clipboard#copy"><%= @account_squad.pin %></code>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -110,11 +110,12 @@
           <%= f.text_field :name, value: @account_squad.name, class: "input", maxlength: 16 %>
         </div>
 
-        <div class="flex flex-col gap-y-1 sm:flex-row sm:items-center sm:gap-x-3 relative" data-controller="clipboard">
+        <div data-controller="clipboard"
+             data-clipboard-content-value="<%= @account_squad.pin %>"
+             class="flex flex-col gap-y-1 sm:flex-row sm:items-center sm:gap-x-3 relative" >
           <span>PIN:</span>
           <code class="w-48 text-center tracking-[0.5rem] copyable"
-                data-action="click->clipboard#copy"
-                data-clipboard-content-value="<%= @account_squad.pin %>"><%= @account_squad.pin %></code>
+                data-action="click->clipboard#copy"><%= @account_squad.pin %></code>
           <span data-clipboard-target="feedback" class="hidden absolute -top-4 right-0 text-xs">Copied!</span>
         </div>
 


### PR DESCRIPTION
## Summary of changes and context

By moving the data-clipboard-content-value attribute next to the data-controller attribute in the HTML.

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
