### PR TITLE
Disable countdown for admins

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,9 @@ class ApplicationController < ActionController::Base
   end
 
   def render_countdown?
-    Time.now.utc < Aoc.lewagon_launch_time && Rails.env.production? && !ENV["THIS_IS_STAGING"]
+    is_before_launch = Time.now.utc < Aoc.lewagon_launch_time
+    is_real_production = Rails.env.production? && !ENV["THIS_IS_STAGING"]
+
+    !devise_controller? && is_before_launch && is_real_production
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,8 @@ class ApplicationController < ActionController::Base
   def render_countdown?
     is_before_launch = Time.now.utc < Aoc.lewagon_launch_time
     is_real_production = Rails.env.production? && !ENV["THIS_IS_STAGING"]
+    is_not_admin = !current_user&.admin?
 
-    !devise_controller? && is_before_launch && is_real_production
+    !devise_controller? && is_not_admin && is_before_launch && is_real_production
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -29,10 +29,6 @@ class PagesController < ApplicationController
     @admins = User.admins.pluck(:username)
   end
 
-  def countdown
-    render_countdown
-  end
-
   def faq; end
 
   def participation

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,7 @@
 
 class PagesController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[admin code_of_conduct faq participation stats welcome]
+  skip_before_action :render_countdown, only: %i[admin]
 
   def admin; end
 


### PR DESCRIPTION
## Summary of changes and context

The countdown is rendered upon these conditions:
* current time has to be before the event starts
* AND the environment is the "real" production (aoc.lewagon.community)
* AND the controller for the request is not a Devise controller (sign in, sign out)
* AND the page is not `/admin`
* AND the user is not an admin

In other words, I'm enabling admins to log in and access the app before the countdown is over. Drawback: any user accessing `/admin` before countdown expires could create their account, though could not access anything.

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
