### PR TITLE
refactor(countdown): clearInterval after countdown finished

### DIFF
--- a/app/javascript/controllers/countdown_controller.js
+++ b/app/javascript/controllers/countdown_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
 
   connect() {
     if (new Date() < new Date(this.launchDateValue)) {
-      setInterval(() => this.#updateClock(), 23)
+      this.interval = setInterval(() => this.#updateClock(), 23)
     }
   }
 
@@ -34,14 +34,12 @@ export default class extends Controller {
     }
 
     // When the countdown is over
+    clearInterval(this.interval)
 
     // Force the timer to 0
     this.millisecondsTarget.innerHTML = "000"
 
-    // Reload the page (only once)
-    if (!this.hasReloaded) {
-      this.hasReloaded = true
-      setTimeout(() => location.reload(), 500)
-    }
+    // Reload the page
+    setTimeout(() => location.reload(), 500)
   }
 }

--- a/app/javascript/controllers/countdown_controller.js
+++ b/app/javascript/controllers/countdown_controller.js
@@ -34,12 +34,14 @@ export default class extends Controller {
     }
 
     // When the countdown is over
+
+    // Properly stop the clock
     clearInterval(this.interval)
 
-    // Force the timer to 0
+    // Force the timer to display 0
     this.millisecondsTarget.innerHTML = "000"
 
     // Reload the page
-    setTimeout(() => location.reload(), 500)
+    location.reload()
   }
 }


### PR DESCRIPTION
## Summary of changes and context
Les multiple redirection que tu as essayé de fix dans https://github.com/pil0u/lewagon-aoc/pull/623 étaient du au fait que tu as mis un timeout sur la redirection. Sauf qu'en attendant que ce timeout soit appliqué, l'interval continuait de loop.

Du coup en 500ms l'interval a eu le temps de loop disons 6 fois, donc 6 timeout ont eu le temps d'etre lancé, d'ou la multiple redirection ensuite.

Ce qu'il aurait fallut faire c'est clear l'interval dès que le timer est terminé pour casser la boucle.

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
