### PR TITLE
Remove `solargraph` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ group :development do
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
   gem "rack-mini-profiler"
-  gem "solargraph"
   # Access an interactive console on exception pages or by calling "console" anywhere in the code.
   gem "web-console"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,10 +78,8 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
-    backport (1.2.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
-    benchmark (0.3.0)
     better_html (2.1.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -126,7 +124,6 @@ GEM
     docile (1.4.1)
     dotenv (3.1.4)
     drb (2.2.1)
-    e2mmap (0.1.0)
     erb_lint (0.6.0)
       activesupport
       better_html (>= 2.0.1)
@@ -185,17 +182,12 @@ GEM
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jaro_winkler (1.6.0)
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.7.2)
     jwt (2.9.3)
       base64
-    kramdown (2.4.0)
-      rexml
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -318,7 +310,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (2.8.4)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -327,8 +318,6 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    reverse_markdown (2.1.1)
-      nokogiri
     rexml (3.3.8)
     rouge (4.4.0)
     rspec-core (3.13.1)
@@ -392,22 +381,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    solargraph (0.50.0)
-      backport (~> 1.2)
-      benchmark
-      bundler (~> 2.0)
-      diff-lcs (~> 1.4)
-      e2mmap
-      jaro_winkler (~> 1.5)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      parser (~> 3.0)
-      rbs (~> 2.0)
-      reverse_markdown (~> 2.0)
-      rubocop (~> 1.38)
-      thor (~> 1.0)
-      tilt (~> 2.0)
-      yard (~> 0.9, >= 0.9.24)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -427,7 +400,6 @@ GEM
     tailwindcss-rails (2.7.8-x86_64-linux)
       railties (>= 7.0.0)
     thor (1.3.2)
-    tilt (2.4.0)
     timeout (0.4.1)
     turbo-rails (2.0.10)
       actionpack (>= 6.0.0)
@@ -456,7 +428,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.37)
     zeitwerk (2.6.18)
 
 PLATFORMS
@@ -501,7 +472,6 @@ DEPENDENCIES
   sentry-ruby
   simplecov
   slack-ruby-client
-  solargraph
   sprockets-rails
   stimulus-rails
   strong_migrations


### PR DESCRIPTION
## Summary of changes and context

When setting up my new VSCode, I figured the new way of doing things is via the `ruby-lsp` instead of `solargraph`.

Keeping `solargraph` in the dependencies prevented the language server to update properly (via VSCode), removing it solved the issue.

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
