### PR TITLE
Fix JS date parsing to display countdown across all browsers

### DIFF
--- a/app/views/pages/countdown.html.erb
+++ b/app/views/pages/countdown.html.erb
@@ -19,7 +19,7 @@
 
     <main class="m-auto">
       <div data-controller="countdown"
-           data-countdown-launch-date-value="<%= Aoc.lewagon_launch_time.strftime('%Y/%m/%d %H:%M:%S %z') %>"
+           data-countdown-launch-date-value="<%= Aoc.lewagon_launch_time.strftime("%Y/%m/%d %H:%M:%S %z") %>"
            class="text-3xl lg:text-6xl text-center h-[30vh]">
         <span data-countdown-target="days"></span>
         <span data-countdown-target="hours"></span>

--- a/app/views/pages/countdown.html.erb
+++ b/app/views/pages/countdown.html.erb
@@ -19,7 +19,7 @@
 
     <main class="m-auto">
       <div data-controller="countdown"
-           data-countdown-launch-date-value="<%= Aoc.lewagon_launch_time %>"
+           data-countdown-launch-date-value="<%= Aoc.lewagon_launch_time.strftime('%Y/%m/%d %H:%M:%S %z') %>"
            class="text-3xl lg:text-6xl text-center h-[30vh]">
         <span data-countdown-target="days"></span>
         <span data-countdown-target="hours"></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,6 @@ Rails.application.routes.draw do
   # Routes for authenticated + confirmed users
   authenticated :user, ->(user) { user.confirmed? } do
     get     "/",                                to: "pages#calendar", as: :calendar
-    get     "/countdown",                       to: "pages#countdown"
     get     "/patrons",                         to: "pages#patrons"
     get     "/campus/:slug",                    to: "campuses#show",   as: :campus
     get     "/city/:slug",                      to: "campuses#show",   as: :city # Retrocompat in case of old links


### PR DESCRIPTION
## Summary of changes and context

Fixes a nasty issue that breaks the countdown on certain browser (Safari, mobile).
[Date parsing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) can be inconsistent in JavaScript, so we use an explicit format that should remove any ambiguity.

Also, remove the `/countdown` route.

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
