### PR TITLE
Truncate long snippets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.8)
+    rexml (3.3.9)
     rouge (4.4.0)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -194,6 +194,10 @@
     text-shadow: 0 0 5px #99c;
   }
 
+  .truncated {
+    @apply max-h-[12rem] overflow-hidden;
+  }
+
   @keyframes wiggle {
     0% { transform: rotate(0deg); }
     70% { transform: rotate(0deg); }

--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -1,4 +1,6 @@
-<div id="<%= @snippet.id %>" class="w-full p-4 flex flex-col self-center gap-y-4 bg-aoc-gray-darkest border border-aoc-gray-dark group">
+<div id="<%= @snippet.id %>"
+     class="w-full p-4 flex flex-col self-center gap-y-4 bg-aoc-gray-darkest border border-aoc-gray-dark group"
+     data-controller="show-more">
   <div class="flex text-xs gap-x-3">
     <%= link_to "permalink", snippet_path(day: @snippet.day, challenge: @snippet.challenge, anchor: @snippet.id), class: "link-explicit" %>
 
@@ -7,9 +9,16 @@
     <% end %>
   </div>
 
-  <pre class="snippet break-words text-sm whitespace-normal" data-language="<%= @snippet.language %>">
-    <%= raw render_markdown @snippet.code, default_language: @snippet.language %>
+  <pre class="snippet break-words text-sm whitespace-normal truncated"
+       data-language="<%= @snippet.language %>"
+       data-show-more-target="codeBlock">
+      <%= raw render_markdown @snippet.code, default_language: @snippet.language %>
   </pre>
+  <button data-action="show-more#toggle"
+          data-show-more-target="button"
+          class="w-full text-xs text-center bg-aoc-green bg-opacity-20 hover:bg-opacity-15 active:bg-opacity-10">
+    ↓↓↓
+  </button>
 
   <hr class="border-aoc-gray-darker">
 

--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -17,7 +17,7 @@
   <button data-action="show-more#toggle"
           data-show-more-target="button"
           class="w-full text-xs text-center bg-aoc-green bg-opacity-20 hover:bg-opacity-15 active:bg-opacity-10">
-    ↓↓↓
+    ↓ Show more ↓
   </button>
 
   <hr class="border-aoc-gray-darker">

--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -34,9 +34,9 @@
     </div>
 
     <div class="flex justify-end gap-x-2">
-      <span class="invisible group-hover:visible text-sm text-aoc-gray-dark"><%= @snippet.created_at %></span>
+      <span class="text-xs text-aoc-gray-dark"><%= @snippet.created_at %></span>
 
-      <em class="text-sm text-aoc-gray-dark">
+      <em class="text-xs text-aoc-gray-dark">
         - <%= link_to(@snippet.user.username, profile_path(@snippet.user.uid), class: "link-explicit group-hover:text-aoc-gray") %>
       </em>
     </div>

--- a/app/controllers/days_controller.rb
+++ b/app/controllers/days_controller.rb
@@ -11,8 +11,8 @@ class DaysController < ApplicationController
     @gold_stars = completions[2].to_i
     @silver_stars = completions[1].to_i - @gold_stars
 
-    @solved_part_one = current_user.solved?(@day, 1)
-    @solved_part_two = current_user.solved?(@day, 2)
+    @part_one_is_unlocked = part_is_unlocked?(1)
+    @part_two_is_unlocked = part_is_unlocked?(2)
     @snippets_part_one = Snippet.where(day: @day, challenge: 1).count
     @snippets_part_two = Snippet.where(day: @day, challenge: 2).count
 
@@ -22,5 +22,12 @@ class DaysController < ApplicationController
     @participants = presenter.get
 
     @puzzle = Puzzle.by_date(Aoc.begin_time.change(day: @day))
+  end
+
+  private
+
+  def part_is_unlocked?(challenge)
+    # Taken from AllowedToSeeSolutionsConstraint
+    current_user.solved?(@day, challenge) || Completion.where(day: @day, challenge:).count >= 5
   end
 end

--- a/app/javascript/controllers/show_more_controller.js
+++ b/app/javascript/controllers/show_more_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["codeBlock", "button"]
+
+    connect() {
+        // Hide the button if the code block is not truncated
+        if (this.codeBlockTarget.scrollHeight <= this.codeBlockTarget.offsetHeight) {
+            this.buttonTarget.classList.add("hidden")
+        }
+    }
+
+    toggle() {
+        const isExpanded = !this.codeBlockTarget.classList.toggle("truncated")
+        this.buttonTarget.textContent = isExpanded ? "↑↑↑" : "↓↓↓"
+    }
+}

--- a/app/javascript/controllers/show_more_controller.js
+++ b/app/javascript/controllers/show_more_controller.js
@@ -13,5 +13,7 @@ export default class extends Controller {
     toggle() {
         const isExpanded = !this.codeBlockTarget.classList.toggle("truncated")
         this.buttonTarget.textContent = isExpanded ? "↑↑↑" : "↓↓↓"
+
+        this.codeBlockTarget.scrollIntoView({ behavior: "smooth" })
     }
 }

--- a/app/javascript/controllers/show_more_controller.js
+++ b/app/javascript/controllers/show_more_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
 
     toggle() {
         const isExpanded = !this.codeBlockTarget.classList.toggle("truncated")
-        this.buttonTarget.textContent = isExpanded ? "↑↑↑" : "↓↓↓"
+        this.buttonTarget.textContent = isExpanded ? "↑ Show less ↑" : "↓ Show more ↓"
 
         this.codeBlockTarget.scrollIntoView({ behavior: "smooth" })
     }

--- a/app/views/days/show.html.erb
+++ b/app/views/days/show.html.erb
@@ -80,6 +80,8 @@
   <% end %>
 </div>
 
+<% if @silver_stars > 0 %>
+
 <div class="pb-2 block overflow-x-auto max-w-full">
   <table class="mx-auto text-right">
     <tr>
@@ -92,6 +94,8 @@
     <%= render Scores::DailyUserRowComponent.with_collection(@participants, user: current_user) %>
   </table>
 </div>
+
+<% end %>
 
 <% else %>
 

--- a/app/views/days/show.html.erb
+++ b/app/views/days/show.html.erb
@@ -39,7 +39,7 @@
 <% if @day <= Aoc.latest_day %>
 
 <div class="my-4 flex flex-wrap justify-center gap-2">
-  <% if @solved_part_one %>
+  <% if @part_one_is_unlocked %>
     <%= link_to snippet_path(day: @day, challenge: 1), class: "w-36 h-36 p-2 flex flex-col justify-between border border-aoc-gray-darker bg-aoc-gray-darkest hover:bg-aoc-gray-darker" do %>
       <h3 class="h-2/5 flex items-center justify-center strong text-center text-lg">
         Solutions
@@ -59,7 +59,7 @@
     <span>Solve the puzzle to share your solution and access others'</span>
   <% end %>
 
-  <% if @solved_part_two %>
+  <% if @part_two_is_unlocked %>
     <%= link_to snippet_path(day: @day, challenge: 2), class: "w-36 h-36 p-2 flex flex-col justify-between border border-aoc-gray-darker bg-aoc-gray-darkest hover:bg-aoc-gray-darker" do %>
       <h3 class="h-2/5 flex items-center justify-center strong text-center text-lg">
         Solutions

--- a/app/views/days/show.html.erb
+++ b/app/views/days/show.html.erb
@@ -56,7 +56,9 @@
       </div>
     <% end %>
   <% else %>
-    <span>Solve the puzzle to share your solution and access others'</span>
+    <span class="max-w-lg text-center">
+      You must <em>either</em> wait for 5 people to solve the puzzle <em>or</em> solve it yourself to see the solutions
+    </span>
   <% end %>
 
   <% if @part_two_is_unlocked %>

--- a/app/views/days/show.html.erb
+++ b/app/views/days/show.html.erb
@@ -38,67 +38,65 @@
 
 <% if @day <= Aoc.latest_day %>
 
-<div class="my-4 flex flex-wrap justify-center gap-2">
-  <% if @part_one_is_unlocked %>
-    <%= link_to snippet_path(day: @day, challenge: 1), class: "w-36 h-36 p-2 flex flex-col justify-between border border-aoc-gray-darker bg-aoc-gray-darkest hover:bg-aoc-gray-darker" do %>
-      <h3 class="h-2/5 flex items-center justify-center strong text-center text-lg">
-        Solutions
-      </h3>
+  <div class="my-4 flex flex-wrap justify-center gap-2">
+    <% if @part_one_is_unlocked %>
+      <%= link_to snippet_path(day: @day, challenge: 1), class: "w-36 h-36 p-2 flex flex-col justify-between border border-aoc-gray-darker bg-aoc-gray-darkest hover:bg-aoc-gray-darker" do %>
+        <h3 class="h-2/5 flex items-center justify-center strong text-center text-lg">
+          Solutions
+        </h3>
 
-      <div class="h-3/5 flex flex-col justify-around">
-        <span class="flex items-center justify-center text-aoc-silver text-lg">
-          Part 1
-        </span>
+        <div class="h-3/5 flex flex-col justify-around">
+          <span class="flex items-center justify-center text-aoc-silver text-lg">
+            Part 1
+          </span>
 
-        <span class="flex items-center justify-center">
-          <%= @snippets_part_one %> shared
-        </span>
-      </div>
+          <span class="flex items-center justify-center">
+            <%= @snippets_part_one %> shared
+          </span>
+        </div>
+      <% end %>
+    <% else %>
+      <span class="max-w-lg text-center">
+        You must <em>either</em> wait for 5 people to solve the puzzle <em>or</em> solve it yourself to see the solutions
+      </span>
     <% end %>
-  <% else %>
-    <span class="max-w-lg text-center">
-      You must <em>either</em> wait for 5 people to solve the puzzle <em>or</em> solve it yourself to see the solutions
-    </span>
-  <% end %>
 
-  <% if @part_two_is_unlocked %>
-    <%= link_to snippet_path(day: @day, challenge: 2), class: "w-36 h-36 p-2 flex flex-col justify-between border border-aoc-gray-darker bg-aoc-gray-darkest hover:bg-aoc-gray-darker" do %>
-      <h3 class="h-2/5 flex items-center justify-center strong text-center text-lg">
-        Solutions
-      </h3>
+    <% if @part_two_is_unlocked %>
+      <%= link_to snippet_path(day: @day, challenge: 2), class: "w-36 h-36 p-2 flex flex-col justify-between border border-aoc-gray-darker bg-aoc-gray-darkest hover:bg-aoc-gray-darker" do %>
+        <h3 class="h-2/5 flex items-center justify-center strong text-center text-lg">
+          Solutions
+        </h3>
 
-      <div class="h-3/5 flex flex-col justify-around">
-        <span class="flex items-center justify-center text-aoc-gold text-lg">
-          Part 2
-        </span>
+        <div class="h-3/5 flex flex-col justify-around">
+          <span class="flex items-center justify-center text-aoc-gold text-lg">
+            Part 2
+          </span>
 
-        <span class="flex items-center justify-center">
-          <%= @snippets_part_two %> shared
-        </span>
-      </div>
+          <span class="flex items-center justify-center">
+            <%= @snippets_part_two %> shared
+          </span>
+        </div>
+      <% end %>
     <% end %>
+  </div>
+
+  <% if @silver_stars > 0 %>
+    <div class="pb-2 block overflow-x-auto max-w-full">
+      <table class="mx-auto text-right">
+        <tr>
+          <th class="min-w-[12rem] lg:min-w-[16rem]"></th>
+          <th class="min-w-[6rem] font-light text-aoc-silver text-center">Part 1</th>
+          <th class="min-w-[6rem] font-light text-aoc-gold text-center">Part 2</th>
+          <th class="min-w-[6rem] font-light strong text-center">Score</th>
+        </tr>
+
+        <%= render Scores::DailyUserRowComponent.with_collection(@participants, user: current_user) %>
+      </table>
+    </div>
   <% end %>
-</div>
-
-<% if @silver_stars > 0 %>
-
-<div class="pb-2 block overflow-x-auto max-w-full">
-  <table class="mx-auto text-right">
-    <tr>
-      <th class="min-w-[12rem] lg:min-w-[16rem]"></th>
-      <th class="min-w-[6rem] font-light text-aoc-silver text-center">Part 1</th>
-      <th class="min-w-[6rem] font-light text-aoc-gold text-center">Part 2</th>
-      <th class="min-w-[6rem] font-light strong text-center">Score</th>
-    </tr>
-
-    <%= render Scores::DailyUserRowComponent.with_collection(@participants, user: current_user) %>
-  </table>
-</div>
-
-<% end %>
 
 <% else %>
 
-<span class="my-8 text-center">Puzzle is not released yet</span>
+  <span class="my-8 text-center">Puzzle is not released yet</span>
 
 <% end %>


### PR DESCRIPTION
## Summary of changes and context

- Closes #265 
  - via a new StimulusJS controller
- Fix `rexml` security vulnerability
- Update the condition to be able to access/post solutions (i.e. solved the puzzle or 5 people solved it)
- Closes #654 

<img width="1018" alt="Screenshot 2024-11-03 at 19 05 21" src="https://github.com/user-attachments/assets/7a34c5ca-fda1-44fd-b625-0ecc95097cd6">

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
