### PR TITLE
Improve reactions style slightly

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -3,10 +3,6 @@
 @import "tailwindcss/components";
 
 @layer components {
-  .bg-hover {
-    @apply bg-aoc-gray bg-opacity-10;
-  }
-
   .button {
     @apply form-element cursor-pointer hover:text-gold;
   }
@@ -20,7 +16,7 @@
   }
 
   .calendar-tile {
-    @apply w-14 h-14 rounded-xl lg:w-20 lg:h-20 lg:rounded-2xl flex items-center justify-center border border-aoc-gray-darker hover:bg-hover;
+    @apply w-14 h-14 rounded-xl lg:w-20 lg:h-20 lg:rounded-2xl flex items-center justify-center border border-aoc-gray-darker hover:bg-aoc-gray/10;
   }
 
   code:not(pre code) {
@@ -106,7 +102,7 @@
   }
 
   .disabled {
-    @apply pointer-events-none bg-aoc-gray-darker text-aoc-gray-dark bg-opacity-40;
+    @apply pointer-events-none bg-aoc-gray-darker/40 text-aoc-gray-dark;
 
     /* For some weird reason, a background opacity >= 50% changes the text color on mobile. WTF. */
   }

--- a/app/components/faq/details_summary_component.html.erb
+++ b/app/components/faq/details_summary_component.html.erb
@@ -1,3 +1,3 @@
-<summary class="my-2 cursor-pointer hover:bg-hover">
+<summary class="my-2 cursor-pointer hover:bg-aoc-gray/10">
   <h3 class="py-1 px-3 text-right font-semibold italic hover:text-white"><%= @title %></h3>
 </summary>

--- a/app/components/scores/campus_row_component.html.erb
+++ b/app/components/scores/campus_row_component.html.erb
@@ -1,6 +1,6 @@
 <%# The scale-100 trick is to make the last td absolute, relative to the tr  %>
 
-<tr class="scale-100 hover:bg-hover <%= "bg-aoc-green bg-opacity-20" if @campus[:id] == @user.city_id %>">
+<tr class="scale-100 hover:bg-aoc-gray/10 <%= "bg-aoc-green/20" if @campus[:id] == @user.city_id %>">
   <td class="<%= class_names(rank_css(@campus[:rank])) %>">
     <%= link_to campus_path(@campus[:slug]), class: "flex justify-center" do %>
       <%= (@campus[:rank] if @campus[:display_rank]) || "&nbsp".html_safe %>

--- a/app/components/scores/daily_user_row_component.html.erb
+++ b/app/components/scores/daily_user_row_component.html.erb
@@ -1,4 +1,4 @@
-<tr class="hover:bg-hover <%= "bg-aoc-green bg-opacity-20" if @participant[:uid] == @user.uid %>">
+<tr class="hover:bg-aoc-gray/10 <%= "bg-aoc-green/20" if @participant[:uid] == @user.uid %>">
   <td>
     <%= link_to profile_path(@participant[:uid]), class: "flex justify-center items-center" do %>
       <%= @participant[:username] %>

--- a/app/components/scores/squad_row_component.html.erb
+++ b/app/components/scores/squad_row_component.html.erb
@@ -1,6 +1,6 @@
 <%# The scale-100 trick is to make the last td absolute, relative to the tr %>
 
-<tr class="scale-100 hover:bg-hover <%= "bg-aoc-green bg-opacity-20" if @user && @squad[:id] == @user.squad_id %>">
+<tr class="scale-100 hover:bg-aoc-gray/10 <%= "bg-aoc-green/20" if @user && @squad[:id] == @user.squad_id %>">
   <td class="<%= class_names(rank_css(@squad[:rank])) %>">
     <%= link_to squad_path(@squad[:id]), class: "flex justify-center" do %>
       <%= (@squad[:rank] if @squad[:display_rank]) || "&nbsp".html_safe %>

--- a/app/components/scores/user_row_component.html.erb
+++ b/app/components/scores/user_row_component.html.erb
@@ -1,7 +1,7 @@
 <%# The scale-100 trick is to make the last td absolute, relative to the tr  %>
 
-<tr class="scale-100 hover:bg-hover
-          <%= "bg-aoc-green bg-opacity-20" if @user && @participant[:uid] == @user.uid.to_i %>
+<tr class="scale-100 hover:bg-aoc-gray/10
+          <%= "bg-aoc-green/20" if @user && @participant[:uid] == @user.uid.to_i %>
           <%= "text-aoc-gray-dark" if @colorize_hardcore && @participant[:entered_hardcore] %>">
 
   <td class="<%= class_names(rank_css(@participant[:rank])) %>">

--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -24,7 +24,7 @@
 
   <div class="w-full flex items-center justify-between">
     <div
-      class="flex items-center gap-x-4"
+      class="flex items-center gap-x-1"
       data-controller="reactions"
       data-reactions-snippet-id-value="<%= @snippet.id %>"
       data-reactions-vote-value="<%= @snippet.reactions.find_by(user_id: @user.id).to_json %>">

--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -16,7 +16,7 @@
   </pre>
   <button data-action="show-more#toggle"
           data-show-more-target="button"
-          class="w-full text-xs text-center bg-aoc-green bg-opacity-20 hover:bg-opacity-15 active:bg-opacity-10">
+          class="w-full text-xs text-center bg-aoc-green/20 hover:bg-aoc-green/15 active:bg-aoc-green/10">
     ↓ Show more ↓
   </button>
 

--- a/app/components/snippets/reaction_component.html.erb
+++ b/app/components/snippets/reaction_component.html.erb
@@ -1,14 +1,20 @@
 <div class="relative group/reaction">
-  <div class="absolute bg-aoc-gray-darker bottom-full hidden mb-2 px-2 py-0.5 right-1/2 rounded shadow-black shadow-lg text-xs translate-x-1/2 w-max group-hover/reaction:block">
+  <div class="hidden group-hover/reaction:block absolute bottom-full left-0 px-2 py-0.5 mb-1 w-max bg-aoc-gray-darker text-xs">
     <%= EMOTES[@reaction_type][:tooltip] %>
   </div>
 
   <%= button_to reactions_path(@snippet.id),
-                class: "border duration-300 px-1.5 rounded-full transition-colors #{'cursor-pointer hover:bg-aoc-gray-darker' unless @snippet.user_id == @user.id}",
+                class: "flex gap-x-2 items-center border px-2 rounded-full #{@snippet.user_id == @user.id ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-aoc-green/15'}",
                 params: { reaction: { reaction_type: @reaction_type } },
                 data: { reactions_target: "button", reaction_type: @reaction_type, action: "click->reactions#handleClick" },
                 disabled: @snippet.user_id == @user.id do %>
-      <%= EMOTES[@reaction_type][:emote] %>
-      <span data-reactions-target="counter" data-reaction-type="<%= @reaction_type %>"><%= @reactions.count %></span>
+      <span>
+        <%= EMOTES[@reaction_type][:emote] %>
+      </span>
+      <span data-reactions-target="counter"
+            data-reaction-type="<%= @reaction_type %>"
+            class="font-semibold">
+        <%= @reactions.count %>
+      </span>
   <% end %>
 </div>

--- a/app/components/snippets/reaction_component.html.erb
+++ b/app/components/snippets/reaction_component.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <%= button_to reactions_path(@snippet.id),
-                class: "flex gap-x-2 items-center border px-2 rounded-full #{@snippet.user_id == @user.id ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-aoc-green/15'}",
+                class: "flex gap-x-2 items-center border px-2 rounded-full #{@snippet.user_id == @user.id ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-aoc-green/15 active:bg-aoc-green/10'}",
                 params: { reaction: { reaction_type: @reaction_type } },
                 data: { reactions_target: "button", reaction_type: @reaction_type, action: "click->reactions#handleClick" },
                 disabled: @snippet.user_id == @user.id do %>

--- a/app/components/stats/tree_row_component.html.erb
+++ b/app/components/stats/tree_row_component.html.erb
@@ -1,4 +1,4 @@
-<tr class="text-lg hover:bg-hover leading-tight">
+<tr class="text-lg hover:bg-aoc-gray/10 leading-tight">
   <td class="min-w-[2rem]">
     <%= link_to day_path(@day[:number]), class: "pl-4 flex justify-end" do %>
       <%= @day[:number] %>

--- a/app/javascript/controllers/reactions_controller.js
+++ b/app/javascript/controllers/reactions_controller.js
@@ -37,11 +37,11 @@ export default class extends Controller {
   #toggleBorder() {
     this.buttonTargets.forEach(button => {
       if (button.dataset.reactionType === this.vote?.reaction_type) {
-        button.classList.add("border-aoc-green")
-        button.classList.remove("border-aoc-gray-dark")
+        button.classList.add("border-aoc-green", "bg-aoc-green/20")
+        button.classList.remove("border-aoc-gray-darker")
       } else {
-        button.classList.add("border-aoc-gray-dark")
-        button.classList.remove("border-aoc-green")
+        button.classList.add("border-aoc-gray-darker")
+        button.classList.remove("border-aoc-green", "bg-aoc-green/20")
       }
     })
   }

--- a/app/views/pages/participation.html.erb
+++ b/app/views/pages/participation.html.erb
@@ -21,7 +21,7 @@
 
   <tbody>
     <% @cities.each do |city| %>
-      <tr class="hover:bg-hover">
+      <tr class="hover:bg-aoc-gray/10">
         <td class="text-center">
           <%= city[:vanity_name] %>
         </td>

--- a/app/views/pages/patrons.html.erb
+++ b/app/views/pages/patrons.html.erb
@@ -60,7 +60,7 @@
 
   <tbody>
     <% @users.each do |user| %>
-      <tr class="hover:bg-hover">
+      <tr class="hover:bg-aoc-gray/10">
         <td class="text-center">
           <%= link_to user["username"], profile_path(user["uid"]), class: "hover:text-gold" %>
         </td>


### PR DESCRIPTION
## Summary of changes and context

- Closes #655 

Before
<img width="580" alt="Screenshot 2024-11-03 at 23 47 50" src="https://github.com/user-attachments/assets/71503ce3-170a-4c5b-b1a6-196d785fc9a4">
After
<img width="580" alt="Screenshot 2024-11-03 at 23 48 16" src="https://github.com/user-attachments/assets/4da87e46-40bd-454b-8610-1289e8c437ca">

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
