### PR TITLE
Rewor `event_awareness` enum and pluralise "year(s) of service"

### DIFF
--- a/app/components/scores/daily_user_row_component.html.erb
+++ b/app/components/scores/daily_user_row_component.html.erb
@@ -5,7 +5,7 @@
       <% if @participant[:years_of_service] > 0 %>
         <%= inline_svg_tag "years_of_service/#{@participant[:years_of_service]}.svg",
                            class: "h-6 w-6 inline-block ml-1",
-                           title: "#{@participant[:years_of_service]} years of service" %>
+                           title: "#{pluralize(@participant[:years_of_service], 'year')} of service" %>
       <% end %>
       <%= image_tag("aoc.gif", class: "w-5 h-5 ml-1") if @participant[:contributor] %>
     <% end %>

--- a/app/components/scores/user_row_component.html.erb
+++ b/app/components/scores/user_row_component.html.erb
@@ -16,7 +16,7 @@
       <% if @participant[:years_of_service] > 0 %>
         <%= inline_svg_tag "years_of_service/#{@participant[:years_of_service]}.svg",
                            class: "h-6 w-6 inline-block ml-1",
-                           title: "#{@participant[:years_of_service]} years of service" %>
+                           title: "#{pluralize(@participant[:years_of_service], 'year')} of service" %>
       <% end %>
       <%= image_tag("aoc.gif", class: "w-5 h-5 ml-1") if @participant[:contributor] %>
     <% end %>

--- a/app/components/users/account_settings_component.rb
+++ b/app/components/users/account_settings_component.rb
@@ -3,11 +3,13 @@
 module Users
   class AccountSettingsComponent < ApplicationComponent
     AWARENESS_OPTIONS = {
+      newsletter: "Email newsletter",
       slack_aoc: "Channel #aoc on Slack",
       slack_general: "Channel #general on Slack",
+      slack_payforward: "Channel #pay-forward on Slack",
       slack_campus: "Your campus channel on Slack",
       slack_batch: "Your batch channel on Slack",
-      newsletter: "Email newsletter"
+      other: "Other"
     }.freeze
 
     def initialize(user:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,15 @@ class User < ApplicationRecord
 
   flag :roles, %i[admin contributor beta_tester]
   delegate :admin?, :contributor?, :beta_tester?, to: :roles
-  enum :event_awareness, { slack_aoc: 0, slack_general: 1, slack_campus: 2, slack_batch: 3, newsletter: 4 }
+  enum :event_awareness, {
+    newsletter: 1,
+    slack_aoc: 2,
+    slack_general: 3,
+    slack_payforward: 4,
+    slack_campus: 5,
+    slack_batch: 6,
+    other: 99
+  }
 
   belongs_to :batch, optional: true
   belongs_to :city, optional: true, touch: true

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
         <% if @user.years_of_service > 0 %>
           <%= inline_svg_tag "years_of_service/#{@user.years_of_service}.svg",
                              class: "h-8 w-8 inline-block",
-                             title: "#{@user.years_of_service} years of service" %>
+                             title: "#{pluralize(@user.years_of_service, 'year')} of service" %>
         <% end %>
       </h2>
 


### PR DESCRIPTION
## Summary of changes and context

- Pluralise "years of service"
- Rework the `event_awareness` enumeration

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
