### PR TITLE
Fix: avoid nil `current_user` breaking stats page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -92,7 +92,7 @@ class PagesController < ApplicationController
                                   end
     @users_per_star = (@daily_completers.map { |h| h[:gold_completers] + h[:silver_completers] }.max.to_f / 50).ceil
 
-    @current_user_solved_today = current_user.completions.where(day: Aoc.latest_day).count
+    @current_user_solved_today = current_user.completions.where(day: Aoc.latest_day).count if current_user.present?
   end
 
   def welcome


### PR DESCRIPTION
## Summary of changes and context

Bug introduced in #670 

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
