### PR TITLE
Feat/snippets/add link to slack

### DIFF
--- a/app/components/snippets/box_component.html.erb
+++ b/app/components/snippets/box_component.html.erb
@@ -1,11 +1,19 @@
 <div id="<%= @snippet.id %>"
      class="w-full p-4 flex flex-col self-center gap-y-4 bg-aoc-gray-darkest border border-aoc-gray-dark group"
      data-controller="show-more">
-  <div class="flex text-xs gap-x-3">
-    <%= link_to "permalink", snippet_path(day: @snippet.day, challenge: @snippet.challenge, anchor: @snippet.id), class: "link-explicit" %>
 
-    <% if @user_can_edit_snippet %>
-      <%= link_to "edit", edit_snippet_path(day: @snippet.day, challenge: @snippet.challenge, id: @snippet.id), class: "link-explicit" %>
+
+  <div class="flex items-center justify-between text-xs">
+    <div class="flex gap-x-3">
+      <%= link_to "permalink", snippet_path(day: @snippet.day, challenge: @snippet.challenge, anchor: @snippet.id), class: "link-explicit" %>
+
+      <% if @user_can_edit_snippet %>
+        <%= link_to "edit", edit_snippet_path(day: @snippet.day, challenge: @snippet.challenge, id: @snippet.id), class: "link-explicit" %>
+      <% end %>
+    </div>
+
+    <% if @user_can_discuss_snippet %>
+      <%= link_to "Discuss this solution", discuss_snippet_path(@snippet), class: "link-slack", target: "_blank" %>
     <% end %>
   </div>
 

--- a/app/components/snippets/box_component.rb
+++ b/app/components/snippets/box_component.rb
@@ -11,6 +11,7 @@ module Snippets
       @snippet = snippet
 
       @user_can_edit_snippet = @snippet.user == @user && Time.now.utc < Aoc.release_time(@snippet.day) + 48.hours
+      @user_can_discuss_snippet = @snippet.user != @user && @snippet.user.slack_id.present?
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,14 +59,15 @@ Rails.application.routes.draw do
   authenticated :user, ->(user) { user.confirmed? } do
     get     "/",                                to: "pages#calendar", as: :calendar
     get     "/patrons",                         to: "pages#patrons"
-    get     "/campus/:slug",                    to: "campuses#show",   as: :campus
-    get     "/city/:slug",                      to: "campuses#show",   as: :city # Retrocompat in case of old links
-    get     "/day/:day",                        to: "days#show",       as: :day,            day: /[1-9]|1\d|2[0-5]/
-    get     "/day/:day/:challenge",             to: "snippets#show",   as: :snippet,        day: /[1-9]|1\d|2[0-5]/, challenge: /[1-2]/, constraints: AllowedToSeeSolutionsConstraint.new
-    post    "/day/:day/:challenge",             to: "snippets#create",                      day: /[1-9]|1\d|2[0-5]/, challenge: /[1-2]/, constraints: AllowedToSeeSolutionsConstraint.new
-    get     "/snippets/:id/edit",               to: "snippets#edit",   as: :edit_snippet,   day: /[1-9]|1\d|2[0-5]/, challenge: /[1-2]/, constraints: AllowedToSeeSolutionsConstraint.new
-    patch   "/snippets/:id",                    to: "snippets#update", as: :update_snippet, day: /[1-9]|1\d|2[0-5]/, challenge: /[1-2]/, constraints: AllowedToSeeSolutionsConstraint.new
-    get     "/the-wall",                        to: "messages#index",  as: :messages
+    get     "/campus/:slug",                    to: "campuses#show",  as: :campus
+    get     "/city/:slug",                      to: "campuses#show",  as: :city # Retrocompat in case of old links
+    get     "/day/:day",                        to: "days#show",      as: :day,              day: /[1-9]|1\d|2[0-5]/
+    get     "/day/:day/:challenge",             to: "snippets#show",  as: :snippet,          day: /[1-9]|1\d|2[0-5]/, challenge: /[1-2]/, constraints: AllowedToSeeSolutionsConstraint.new
+    post    "/day/:day/:challenge",             to: "snippets#create",                       day: /[1-9]|1\d|2[0-5]/, challenge: /[1-2]/, constraints: AllowedToSeeSolutionsConstraint.new
+    get     "/snippets/:id/edit",               to: "snippets#edit",    as: :edit_snippet,   day: /[1-9]|1\d|2[0-5]/, challenge: /[1-2]/, constraints: AllowedToSeeSolutionsConstraint.new
+    patch   "/snippets/:id",                    to: "snippets#update",  as: :update_snippet, day: /[1-9]|1\d|2[0-5]/, challenge: /[1-2]/, constraints: AllowedToSeeSolutionsConstraint.new
+    get     "/snippets/:id/discuss",            to: "snippets#discuss", as: :discuss_snippet
+    get     "/the-wall",                        to: "messages#index",   as: :messages
     post    "/the-wall",                        to: "messages#create"
     get     "/scores/squads",                   to: "scores#squads",    as: :scores_squads
     get     "/squad/:id",                       to: "squads#show",      as: :squad

--- a/db/migrate/20241116190301_add_slack_url_to_snippets.rb
+++ b/db/migrate/20241116190301_add_slack_url_to_snippets.rb
@@ -1,0 +1,5 @@
+class AddSlackUrlToSnippets < ActiveRecord::Migration[7.2]
+  def change
+    add_column :snippets, :slack_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_25_155835) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_16_190301) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -306,6 +306,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_25_155835) do
     t.datetime "created_at", null: false
     t.integer "day"
     t.text "language"
+    t.string "slack_url"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id", "day", "challenge", "language"], name: "index_snippets_on_user_id_and_day_and_challenge_and_language", unique: true


### PR DESCRIPTION
## Summary of changes and context
![image](https://github.com/user-attachments/assets/3a0adc14-32d1-4f29-ab78-c2e5b8b56099)

Small PR to add a "discuss this solution" button on snippets (currently only visible if the snippet's user is not the current user and if the snippet user has linked its Slack account) to be redirected to an existing thread, or a newly created thread if non existed, for the given snippet.

An additional condition was mentioned about only allowing users to generate 1 thread per hour but I'm not convince about that solution tbh
- firstly because if I want to ask 2 questions at once and those are the only one for the next 4 days I don't think that should be prevented
- having to come back again an hour later would probably deter the user from asking at all
- finally it's likely that sometimes the thread already exists so there's no reason to prevent a user from clicking on that button then, but it would also be a bad UX imo to sometimes click on a button and be redirected to a thread because it already exists, and sometimes be given an error saying I created too many thread for now. The user doesn't know how the button work, they just want to be redirected to Slack


## Sanity checks

<!-- Add more checks if you did more -->

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
- [ ] Merge conflicts are resolved
