### PR TITLE
Order patrons by `aura` descending

### DIFF
--- a/app/models/concerns/referrable.rb
+++ b/app/models/concerns/referrable.rb
@@ -59,7 +59,8 @@ module Referrable
         LEFT JOIN (SELECT user_id, COUNT(id) AS total FROM snippets GROUP BY user_id) AS snippets
             ON referees.id = snippets.user_id
         WHERE referees.referrer_id IS NOT NULL
-        GROUP BY 1, 2;
+        GROUP BY 1, 2
+        ORDER BY aura DESC;
       SQL
 
       ActiveRecord::Base.connection.exec_query(query, "SQL")


### PR DESCRIPTION
## Summary of changes and context

Users are not properly ordered by aura descending in production.
This is the fix.

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
