### PR TITLE
Add indicator for daily puzzle difficulty

### DIFF
--- a/app/controllers/days_controller.rb
+++ b/app/controllers/days_controller.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class DaysController < ApplicationController
+  DIFFICULTY_LEVELS = {
+    1 => { difficulty: "EASY", colour: "🟢" },
+    2 => { difficulty: "HARD", colour: "🟡" },
+    3 => { difficulty: "VERY HARD", colour: "🟠" },
+    4 => { difficulty: "HARDCORE", colour: "🔴" },
+    5 => { difficulty: "IMPOSSIBLE", colour: "⚫" }
+  }.freeze
+
+  DEFAULT_DIFFICULTY = { difficulty: "UNKNOWN", colour: "⚪" }.freeze
+
   def show
     @day = params[:day].to_i
 
@@ -22,6 +32,14 @@ class DaysController < ApplicationController
     @participants = presenter.get
 
     @puzzle = Puzzle.by_date(Aoc.begin_time.change(day: @day))
+
+    @part_1 = DIFFICULTY_LEVELS[@puzzle&.difficulty_part_1] || DEFAULT_DIFFICULTY
+    @part_2 = DIFFICULTY_LEVELS[@puzzle&.difficulty_part_2] || DEFAULT_DIFFICULTY
+    @difficulty_title = <<~TEXT
+      Estimated difficulty (experimental)
+      Part 1: #{@part_1[:difficulty]} #{@part_1[:colour]}
+      Part 2: #{@part_2[:difficulty]} #{@part_2[:colour]}
+    TEXT
   end
 
   private

--- a/app/controllers/days_controller.rb
+++ b/app/controllers/days_controller.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 class DaysController < ApplicationController
-  DIFFICULTY_LEVELS = {
-    1 => { difficulty: "EASY", colour: "🟢" },
-    2 => { difficulty: "HARD", colour: "🟡" },
-    3 => { difficulty: "VERY HARD", colour: "🟠" },
-    4 => { difficulty: "HARDCORE", colour: "🔴" },
-    5 => { difficulty: "IMPOSSIBLE", colour: "⚫" }
-  }.freeze
-
-  DEFAULT_DIFFICULTY = { difficulty: "UNKNOWN", colour: "⚪" }.freeze
-
   def show
     @day = params[:day].to_i
 
@@ -33,8 +23,8 @@ class DaysController < ApplicationController
 
     @puzzle = Puzzle.by_date(Aoc.begin_time.change(day: @day))
 
-    @part_1 = DIFFICULTY_LEVELS[@puzzle&.difficulty_part_1] || DEFAULT_DIFFICULTY
-    @part_2 = DIFFICULTY_LEVELS[@puzzle&.difficulty_part_2] || DEFAULT_DIFFICULTY
+    @part_1 = Puzzle::DIFFICULTY_LEVELS[@puzzle&.difficulty_part_1] || Puzzle::DEFAULT_DIFFICULTY
+    @part_2 = Puzzle::DIFFICULTY_LEVELS[@puzzle&.difficulty_part_2] || Puzzle::DEFAULT_DIFFICULTY
     @difficulty_title = <<~TEXT
       Estimated difficulty (experimental)
       Part 1: #{@part_1[:difficulty]} #{@part_1[:colour]}

--- a/app/jobs/update_puzzles_difficulty_job.rb
+++ b/app/jobs/update_puzzles_difficulty_job.rb
@@ -11,10 +11,10 @@ class UpdatePuzzlesDifficultyJob < ApplicationJob
       return
     end
 
-    puzzles.each do |puzzle|
-      client = Slack::Web::Client.new
-      channel = "#aoc-dev"
+    client = Slack::Web::Client.new
+    channel = "#aoc-dev"
 
+    puzzles.each do |puzzle|
       day = puzzle.date.day
       url = URI("https://aoc-difficulty.ew.r.appspot.com/score?year=#{puzzle.date.year}&day=#{day}")
 
@@ -35,6 +35,13 @@ class UpdatePuzzlesDifficultyJob < ApplicationJob
         difficulty_part_2: data["2"]["quartile"],
         is_difficulty_final: data["1"]["final"] && data["2"]["final"]
       )
+
+      next unless puzzle.is_difficulty_final
+
+      text = "Estimated difficulty for day #{day} (experimental feature):"
+      text += "\n- part 1 is *`#{Puzzle::DIFFICULTY_LEVELS[puzzle.difficulty_part_1][:difficulty]}`* #{Puzzle::DIFFICULTY_LEVELS[puzzle.difficulty_part_1][:colour]}"
+      text += "\n- part 2 is *`#{Puzzle::DIFFICULTY_LEVELS[puzzle.difficulty_part_2][:difficulty]}`* #{Puzzle::DIFFICULTY_LEVELS[puzzle.difficulty_part_2][:colour]}"
+      client.chat_postMessage(channel: ENV.fetch("SLACK_CHANNEL", "#aoc-dev"), text:)
     end
 
     Rails.logger.info "✔ Puzzle difficulties updated"

--- a/app/jobs/update_puzzles_difficulty_job.rb
+++ b/app/jobs/update_puzzles_difficulty_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdatePuzzlesDifficultyJob < ApplicationJob
+  queue_as :default
+
+  def perform; end
+end

--- a/app/jobs/update_puzzles_difficulty_job.rb
+++ b/app/jobs/update_puzzles_difficulty_job.rb
@@ -38,9 +38,15 @@ class UpdatePuzzlesDifficultyJob < ApplicationJob
 
       next unless puzzle.is_difficulty_final
 
-      text = "Estimated difficulty for day #{day} (experimental feature):"
-      text += "\n- part 1 is *`#{Puzzle::DIFFICULTY_LEVELS[puzzle.difficulty_part_1][:difficulty]}`* #{Puzzle::DIFFICULTY_LEVELS[puzzle.difficulty_part_1][:colour]}"
-      text += "\n- part 2 is *`#{Puzzle::DIFFICULTY_LEVELS[puzzle.difficulty_part_2][:difficulty]}`* #{Puzzle::DIFFICULTY_LEVELS[puzzle.difficulty_part_2][:colour]}"
+      part_1 = Puzzle::DIFFICULTY_LEVELS[puzzle.difficulty_part_1]
+      part_2 = Puzzle::DIFFICULTY_LEVELS[puzzle.difficulty_part_2]
+
+      text = <<~TEXT
+        Estimated difficulty for day #{day} (experimental feature):
+        - part 1 is *`#{part_1[:difficulty]}`* #{part_1[:colour]}
+        - part 2 is *`#{part_2[:difficulty]}`* #{part_2[:colour]}
+      TEXT
+
       client.chat_postMessage(channel: ENV.fetch("SLACK_CHANNEL", "#aoc-dev"), text:)
     end
 

--- a/app/jobs/update_puzzles_difficulty_job.rb
+++ b/app/jobs/update_puzzles_difficulty_job.rb
@@ -3,5 +3,40 @@
 class UpdatePuzzlesDifficultyJob < ApplicationJob
   queue_as :default
 
-  def perform; end
+  def perform
+    puzzles = Puzzle.where(is_difficulty_final: false)
+
+    if puzzles.empty?
+      Rails.logger.info "✔ No puzzle difficulty to update"
+      return
+    end
+
+    puzzles.each do |puzzle|
+      client = Slack::Web::Client.new
+      channel = "#aoc-dev"
+
+      day = puzzle.date.day
+      url = URI("https://aoc-difficulty.ew.r.appspot.com/score?year=#{puzzle.date.year}&day=#{day}")
+
+      Rails.logger.info "\tUpdating difficulty for day #{day}..."
+      response = Net::HTTP.get_response(url)
+
+      if response.code != "200" || response.body.include?("error")
+        text = "⚠️ <@URZ0F4TEF> Error updating difficulty for day #{day} (#{response.code})"
+        message = client.chat_postMessage(channel:, text:)
+        client.chat_postMessage(channel:, thread_ts: message["message"]["ts"], text: "#{url}\n```#{response.body}```")
+        next
+      end
+
+      data = JSON.parse(response.body)
+
+      puzzle.update(
+        difficulty_part_1: data["1"]["quartile"],
+        difficulty_part_2: data["2"]["quartile"],
+        is_difficulty_final: data["1"]["final"] && data["2"]["final"]
+      )
+    end
+
+    Rails.logger.info "✔ Puzzle difficulties updated"
+  end
 end

--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -3,6 +3,16 @@
 class Puzzle < ApplicationRecord
   validate :date_during_aoc
 
+  DIFFICULTY_LEVELS = {
+    1 => { difficulty: "EASY", colour: "🟢" },
+    2 => { difficulty: "HARD", colour: "🟡" },
+    3 => { difficulty: "VERY HARD", colour: "🟠" },
+    4 => { difficulty: "HARDCORE", colour: "🔴" },
+    5 => { difficulty: "IMPOSSIBLE", colour: "⚫" }
+  }.freeze
+
+  DEFAULT_DIFFICULTY = { difficulty: "UNKNOWN", colour: "⚪" }.freeze
+
   def url
     Aoc.url(date.day)
   end

--- a/app/views/days/show.html.erb
+++ b/app/views/days/show.html.erb
@@ -2,6 +2,11 @@
   <div class="flex flex-wrap gap-x-6">
     <h2 class="strong">Day <%= @day %></h2>
 
+    <span class="opacity-70"
+          title="<%= @difficulty_title %>">
+      <%= @part_1[:colour] %><%= @part_2[:colour] %>
+    </span>
+
     <% if @day <= Aoc.latest_day %>
       <span>·</span>
       <%= link_to "puzzle", Aoc.url(@day), target: :_blank, rel: :noopener, class: "link-explicit link-external" %>

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -9,23 +9,32 @@ Rails.application.configure do
     shutdown_timeout: 30,
     enable_cron: true,
     cron: {
-      insert_new_completions: {                   # every 10 minutes between November 1st and December 30th
+      # every 10 minutes between November 1st and December 30th
+      insert_new_completions: {
         cron: "*/10 * 1-30 11-12 *",
         class: "InsertNewCompletionsJob"
       },
-      cache_cleanup: {                            # every puzzle day, 5 minutes before a new puzzle is released
+      # every puzzle day, 5 minutes before a new puzzle is released
+      cache_cleanup: {
         cron: "55 23 1-25 12 * America/New_York",
         class: "Cache::CleanupJob"
       },
-      generate_slack_thread: {                    # every puzzle day, 1 minutes after a new puzzle is released
+      # every puzzle day, 1 minutes after a new puzzle is released
+      generate_slack_thread: {
         cron: "1 0 1-25 12 * America/New_York",
         class: "GenerateSlackThread",
         args: -> { [Time.current] }
       },
-      buddies_generate_daily_pairs: {             # every puzzle day, 5 minutes after a new puzzle is released
+      # every puzzle day, 5 minutes after a new puzzle is released
+      buddies_generate_daily_pairs: {
         cron: "5 0 1-25 12 * America/New_York",
         class: "Buddies::GenerateDailyPairsJob",
         args: -> { [Aoc.latest_day] }
+      },
+      # every puzzle day, every 5 minutes for 3 hours after a new puzzle is released
+      update_puzzles_difficulty: {
+        cron: "*/5 0-2 1-25 12 * America/New_York",
+        class: "UpdatePuzzlesDifficultyJob"
       }
     }
   }

--- a/db/migrate/20241122142117_add_difficulty_fields_to_puzzle.rb
+++ b/db/migrate/20241122142117_add_difficulty_fields_to_puzzle.rb
@@ -2,7 +2,8 @@
 
 class AddDifficultyFieldsToPuzzle < ActiveRecord::Migration[7.2]
   def change
-    add_column :puzzles, :difficulty_level, :integer
+    add_column :puzzles, :difficulty_part_1, :integer
+    add_column :puzzles, :difficulty_part_2, :integer
     add_column :puzzles, :is_difficulty_final, :boolean, default: false, null: false
   end
 end

--- a/db/migrate/20241122142117_add_difficulty_fields_to_puzzle.rb
+++ b/db/migrate/20241122142117_add_difficulty_fields_to_puzzle.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDifficultyFieldsToPuzzle < ActiveRecord::Migration[7.2]
+  def change
+    add_column :puzzles, :difficulty_level, :integer
+    add_column :puzzles, :is_difficulty_final, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_16_213617) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_22_142117) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -282,6 +282,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_16_213617) do
   create_table "puzzles", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.date "date", null: false
+    t.integer "difficulty_level"
+    t.boolean "is_difficulty_final", default: false, null: false
     t.string "slack_url"
     t.string "thread_ts"
     t.string "title"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -282,7 +282,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_22_142117) do
   create_table "puzzles", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.date "date", null: false
-    t.integer "difficulty_level"
+    t.integer "difficulty_part_1"
+    t.integer "difficulty_part_2"
     t.boolean "is_difficulty_final", default: false, null: false
     t.string "slack_url"
     t.string "thread_ts"


### PR DESCRIPTION
## Summary of changes and context

* Closes #81 
* Job runs every 5 minutes from puzzle release during 3 hours
* Job only update difficulty for puzzles without a _final_ difficulty
* Job sends a Slack message in `#aoc-dev` in case of failure to fetch the data
* Add an indicator on Day pages
* Send a Slack message in `#aoc` when the estimated difficulty is final$

<img width="481" alt="Screenshot 2024-11-24 at 21 54 28" src="https://github.com/user-attachments/assets/32c2f6ea-0b43-4d06-af63-b9456928b73a">
<img width="481" alt="Screenshot 2024-11-24 at 21 54 21" src="https://github.com/user-attachments/assets/4ce3f750-8cdb-4870-ad9a-f07a496d31ea">


## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
