### PR TITLE
fix(slack): hide slack link button in setup when linked

### DIFF
--- a/app/jobs/buddies/generate_daily_pairs_job.rb
+++ b/app/jobs/buddies/generate_daily_pairs_job.rb
@@ -27,7 +27,7 @@ module Buddies
     private
 
     def retrieve_users_with_slack_linked
-      @user_ids = User.slack_linked.order(:id).pluck(:id)
+      @user_ids = User.slack_linked.where(synced: true).order(:id).pluck(:id)
     end
 
     def handle_odd_number_of_users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ApplicationRecord
   scope :admins, -> { where_roles(:admin) }
   scope :confirmed, -> { where(accepted_coc: true, synced: true).where.not(aoc_id: nil) }
   scope :insanity, -> { where(entered_hardcore: true) } # All users are 'hardcore' since 2024 edition
-  scope :slack_linked, -> { where(synced: true).where.not(slack_id: nil) }
+  scope :slack_linked, -> { where.not(slack_id: nil) }
 
   def self.from_kitt(auth)
     original_batch = auth.info.schoolings&.min_by { |batch| batch.camp.starts_at }
@@ -68,7 +68,7 @@ class User < ApplicationRecord
   end
 
   def slack_linked?
-    synced && slack_id.present?
+    slack_id.present?
   end
 
   def slack_link

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,18 +57,14 @@ RSpec.describe User do
 
   describe "Slack linking scope" do
     it "ensures slack_linked scope and slack_linked? method are in sync" do
-      user_with_slack = create(:user, slack_id: "ABC123", synced: true)
-      user_without_slack = create(:user, slack_id: nil, synced: true)
-      user_with_unsynced_slack = create(:user, slack_id: "DEF456", synced: false)
+      user_with_slack = create(:user, slack_id: "ABC123")
+      user_without_slack = create(:user, slack_id: nil)
 
       expect(User.slack_linked).to include(user_with_slack)
       expect(user_with_slack.slack_linked?).to be true
 
       expect(User.slack_linked).not_to include(user_without_slack)
       expect(user_without_slack.slack_linked?).to be false
-
-      expect(User.slack_linked).not_to include(user_with_unsynced_slack)
-      expect(user_with_unsynced_slack.slack_linked?).to be false
     end
   end
 


### PR DESCRIPTION
## Summary of changes and context
Users in the setup are not `synced` but are already able to connect to slack.
Because of the current `slack_linked?` method definition the "link to slack" button would still appear while they're on the setup page even when linked

## Sanity checks

<!-- Add more checks if you did more -->

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
- [ ] Merge conflicts are resolved
