### PR TITLE
fix(puzzles): Better handle GenerateSlackThread job errors and incomplete puzzle data

### DIFF
--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -79,6 +79,8 @@ class SnippetsController < ApplicationController
 
   def post_slack_message
     puzzle = Puzzle.by_date(Aoc.begin_time.change(day: params[:day]))
+    return if puzzle.thread_ts.nil?
+
     username = "<#{helpers.profile_url(current_user.uid)}|#{current_user.username}>"
     text = "#{username} submitted a new #{solution_markdown} for part #{params[:challenge]} in :#{@snippet.language}-hd:"
     client.chat_postMessage(channel: ENV.fetch("SLACK_CHANNEL", "#aoc-dev"), text:, thread_ts: puzzle.thread_ts)

--- a/app/errors/SlackError.rb
+++ b/app/errors/SlackError.rb
@@ -1,0 +1,1 @@
+class SlackError < StandardError; end

--- a/app/errors/slack_error.rb
+++ b/app/errors/slack_error.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 class SlackError < StandardError; end

--- a/app/jobs/generate_slack_thread.rb
+++ b/app/jobs/generate_slack_thread.rb
@@ -63,7 +63,7 @@ class GenerateSlackThread < ApplicationJob
       day = @puzzle.date.day
       client.chat_postMessage(
         channel: "#aoc-dev",
-        text: "Title not found for day ##{day}, run bundle exec rake 'update_puzzle_thread[#{day},#{channel}]'"
+        text: "Title not found for day ##{day}, run `bundle exec rake 'update_puzzle_thread[#{day},#{channel}]'`"
       )
 
       nil

--- a/app/jobs/generate_slack_thread.rb
+++ b/app/jobs/generate_slack_thread.rb
@@ -10,7 +10,7 @@ class GenerateSlackThread < ApplicationJob
   end
 
   def perform(date)
-    @puzzle = Puzzle.fins_or_create_by(date:)
+    @puzzle = Puzzle.find_or_create_by(date:)
     return if @puzzle.slack_url.present?
 
     if @puzzle.persisted?

--- a/app/jobs/generate_slack_thread.rb
+++ b/app/jobs/generate_slack_thread.rb
@@ -60,7 +60,12 @@ class GenerateSlackThread < ApplicationJob
 
       "`SPOILER` <#{@puzzle.url}|#{raw_title.gsub('---', '').strip}>" if raw_title.present?
     rescue OpenURI::HTTPError
-      client.chat_postMessage(channel: "#aoc-dev", text: "Title not found for day ##{@puzzle.date.day}")
+      day = @puzzle.date.day
+      client.chat_postMessage(
+        channel: "#aoc-dev",
+        text: "Title not found for day ##{day}, run bundle exec rake 'update_puzzle_thread[#{day},#{channel}]'"
+      )
+
       nil
     end
   end

--- a/app/views/days/show.html.erb
+++ b/app/views/days/show.html.erb
@@ -11,7 +11,7 @@
       <span>·</span>
       <%= link_to "puzzle", Aoc.url(@day), target: :_blank, rel: :noopener, class: "link-explicit link-external" %>
 
-      <% if @puzzle.present? %>
+      <% if @puzzle.slack_url.present? %>
         <span>·</span>
         <%= link_to "slack thread", @puzzle.slack_url, target: :_blank, rel: :noopener, class: "link-explicit link-slack" %>
       <% end %>

--- a/lib/tasks/update_puzzle_thread.rake
+++ b/lib/tasks/update_puzzle_thread.rake
@@ -1,7 +1,9 @@
-desc 'update_puzzle_thread'
-task :update_puzzle_thread, [:day, :channel] => :environment do |_, args|
+# frozen_string_literal: true
+
+desc "update_puzzle_thread"
+task :update_puzzle_thread, %i[day channel] => :environment do |_, args|
   next p "day param missing" if args[:day].nil?
-  next p "channel missing or incorrect" unless args[:channel].in? ['aoc', 'aoc-dev']
+  next p "channel missing or incorrect" unless args[:channel].in? %w[aoc aoc-dev]
 
   puzzle = Puzzle.by_date(Aoc.begin_time.change(day: args[:day]))
   next p "Puzzle not found" if puzzle.nil?

--- a/lib/tasks/update_puzzle_thread.rake
+++ b/lib/tasks/update_puzzle_thread.rake
@@ -1,0 +1,21 @@
+desc 'update_puzzle_thread'
+task :update_puzzle_thread, [:day, :channel] => :environment do |_, args|
+  next p "day param missing" if args[:day].nil?
+  next p "channel missing or incorrect" unless args[:channel].in? ['aoc', 'aoc-dev']
+
+  puzzle = Puzzle.by_date(Aoc.begin_time.change(day: args[:day]))
+  next p "Puzzle not found" if puzzle.nil?
+
+  html = URI.parse(@puzzle.url).open
+  doc = Nokogiri::HTML(html)
+  titles = doc.css("h2").map(&:text)
+  raw_title = titles.find { |title| title.match?(/--- Day \d+:/) }
+  next p "Title not found" if raw_title.nil?
+
+  client = Slack::Web::Client.new
+  text = "`SPOILER` <#{@puzzle.url}|#{raw_title.gsub('---', '').strip}>"
+  response = client.chat_update(channel: args[:channel], ts: puzzle.thread_ts, text:)
+  next p "Failed to update message" unless response["ok"]
+
+  puzzle.update!(title: text)
+end


### PR DESCRIPTION
## Summary of changes and context

Basically now a slack thread will be created if a title can't be found, it will use a placeholder title instead and will send a log in `#aoc-dev` with a rake task command to update the title in Slack.

Errors raised from failing to generate a message in Slack will rerun the GenerateSlackThread job up to 5 times after which it will also run a log in aoc-dev (3s interval between retries)

Because of the retries the job was made indempotent.

Finally I updated some conditions in the code to avoid throwing errors if some data is missing from the Puzzle

## Sanity checks

<!-- Add more checks if you did more -->

- [ ] Linters pass
- [ ] Tests pass
- [ ] Related GitHub issues are linked in the description
- [ ] Merge conflicts are resolved
