### PR TITLE
feat(slack): update thread message when creating snippets

### DIFF
--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -64,7 +64,7 @@ class SnippetsController < ApplicationController
     return redirect_to @snippet.slack_url if @snippet.slack_url.present?
 
     text = "`SOLUTION` Hey <@#{@snippet.user.slack_id}>, some people want to discuss your :#{@snippet.language}-hd: #{solution_markdown} on puzzle #{@snippet.day} part #{@snippet.challenge}"
-    message = client.chat_postMessage(channel: ENV.fetch("SLACK_CHANNEL", "#aoc-dev"), text:)
+    message = client.chat_postMessage(channel: ENV.fetch("SLACK_CHANNEL", "C064BH3TLGJ"), text:)
     slack_thread = client.chat_getPermalink(channel: message["channel"], message_ts: message["message"]["ts"])
     @snippet.update(slack_url: slack_thread[:permalink])
 
@@ -83,7 +83,7 @@ class SnippetsController < ApplicationController
 
     username = "<#{helpers.profile_url(current_user.uid)}|#{current_user.username}>"
     text = "#{username} submitted a new #{solution_markdown} for part #{params[:challenge]} in :#{@snippet.language}-hd:"
-    client.chat_postMessage(channel: ENV.fetch("SLACK_CHANNEL", "#aoc-dev"), text:, thread_ts: puzzle.thread_ts)
+    client.chat_postMessage(channel: ENV.fetch("SLACK_CHANNEL", "C064BH3TLGJ"), text:, thread_ts: puzzle.thread_ts)
   end
 
   def set_snippet

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -83,11 +83,11 @@ class SnippetsController < ApplicationController
     return if puzzle.thread_ts.nil?
 
     snippets = Snippet.includes(:user).where(day: @snippet.day)
-    part1, part2 = snippets.partition { |snippet| snippet.challenge == 1 }.map do |solutions|
+    part_one, part_two = snippets.partition { |snippet| snippet.challenge == 1 }.map do |solutions|
       solutions.map { |snippet| solution_markdown(snippet, "#{snippet.user.username} :#{snippet.language}-hd:") }
     end
 
-    text = "#{puzzle.title}\n\nSolutions for part 1: #{part1.join(', ')}\nSolutions for part 2: #{part2.join(', ')}"
+    text = "#{puzzle.title}\n\nSolutions for part 1: #{part_one.join(', ')}\nSolutions for part 2: #{part_two.join(', ')}"
     client.chat_update(channel: ENV.fetch("SLACK_CHANNEL", "C064BH3TLGJ"), text:, ts: puzzle.thread_ts)
   end
 

--- a/app/domains/completions/fetcher.rb
+++ b/app/domains/completions/fetcher.rb
@@ -73,7 +73,7 @@ module Completions
         JSON.parse(response.body)["members"]
       rescue JSON::ParserError => e
         client = Slack::Web::Client.new
-        channel = "#aoc-dev"
+        channel = "C064BH3TLGJ"
 
         if Rails.env.development? || (Rails.env.production? && ENV.fetch("THIS_IS_STAGING", nil))
           text = "(not prod) Failed to parse JSON from AoC API"

--- a/app/jobs/generate_slack_thread.rb
+++ b/app/jobs/generate_slack_thread.rb
@@ -6,7 +6,7 @@ class GenerateSlackThread < ApplicationJob
   queue_as :default
 
   retry_on SlackError do |_, error|
-    client.chat_postMessage(channel: "#aoc-dev", text: error)
+    client.chat_postMessage(channel: "C064BH3TLGJ", text: error)
   end
 
   def perform(date)
@@ -19,14 +19,14 @@ class GenerateSlackThread < ApplicationJob
       @puzzle.slack_url = permalink
       @puzzle.save!
     else
-      client.chat_postMessage(channel: "#aoc-dev", text: @puzzle.errors.full_messages.join(", "))
+      client.chat_postMessage(channel: "C064BH3TLGJ", text: @puzzle.errors.full_messages.join(", "))
     end
   end
 
   private
 
   def channel
-    ENV.fetch("SLACK_CHANNEL", "#aoc-dev")
+    ENV.fetch("SLACK_CHANNEL", "C064BH3TLGJ")
   end
 
   def client
@@ -64,7 +64,7 @@ class GenerateSlackThread < ApplicationJob
     rescue OpenURI::HTTPError
       day = @puzzle.date.day
       client.chat_postMessage(
-        channel: "#aoc-dev",
+        channel: "C064BH3TLGJ",
         text: "Title not found for day ##{day}, run `bundle exec rake 'update_puzzle_thread[#{day},#{channel}]'`"
       )
 

--- a/app/jobs/generate_slack_thread.rb
+++ b/app/jobs/generate_slack_thread.rb
@@ -14,10 +14,9 @@ class GenerateSlackThread < ApplicationJob
     return if @puzzle.slack_url.present?
 
     if @puzzle.persisted?
-      @puzzle.title = scraped_title || "`SPOILER` <#{@puzzle.url}|Day #{date.day}>"
-      @puzzle.thread_ts = message["message"]["ts"]
-      @puzzle.slack_url = permalink
-      @puzzle.save!
+      @puzzle.update!(title: scraped_title || "`SPOILER` <#{@puzzle.url}|Day #{date.day}>")
+      @puzzle.update!(thread_ts: message["message"]["ts"])
+      @puzzle.update!(slack_url: permalink)
     else
       client.chat_postMessage(channel: "C064BH3TLGJ", text: @puzzle.errors.full_messages.join(", "))
     end

--- a/app/jobs/generate_slack_thread.rb
+++ b/app/jobs/generate_slack_thread.rb
@@ -46,10 +46,10 @@ class GenerateSlackThread < ApplicationJob
 
   def permalink
     @permalink ||= begin
-      response = client.chat_getPermalink(channel:, message_ts: message["message"]["ts"])[:permalink]
+      response = client.chat_getPermalink(channel:, message_ts: message["message"]["ts"])
       raise SlackError.new, "Failed to get permalink for day ##{@puzzle.date.day}" unless response["ok"]
 
-      response
+      response[:permalink]
     end
   end
 

--- a/app/jobs/update_puzzles_difficulty_job.rb
+++ b/app/jobs/update_puzzles_difficulty_job.rb
@@ -12,7 +12,7 @@ class UpdatePuzzlesDifficultyJob < ApplicationJob
     end
 
     client = Slack::Web::Client.new
-    channel = "#aoc-dev"
+    channel = "C064BH3TLGJ"
 
     puzzles.each do |puzzle|
       day = puzzle.date.day
@@ -47,7 +47,7 @@ class UpdatePuzzlesDifficultyJob < ApplicationJob
         - part 2 is *`#{part_2[:difficulty]}`* #{part_2[:colour]}
       TEXT
 
-      client.chat_postMessage(channel: ENV.fetch("SLACK_CHANNEL", "#aoc-dev"), text:)
+      client.chat_postMessage(channel: ENV.fetch("SLACK_CHANNEL", "C064BH3TLGJ"), text:)
     end
 
     Rails.logger.info "✔ Puzzle difficulties updated"

--- a/app/views/days/show.html.erb
+++ b/app/views/days/show.html.erb
@@ -11,7 +11,7 @@
       <span>·</span>
       <%= link_to "puzzle", Aoc.url(@day), target: :_blank, rel: :noopener, class: "link-explicit link-external" %>
 
-      <% if @puzzle.slack_url.present? %>
+      <% if @puzzle&.slack_url.present? %>
         <span>·</span>
         <%= link_to "slack thread", @puzzle.slack_url, target: :_blank, rel: :noopener, class: "link-explicit link-slack" %>
       <% end %>

--- a/lib/tasks/update_puzzle_thread.rake
+++ b/lib/tasks/update_puzzle_thread.rake
@@ -3,7 +3,7 @@
 desc "update_puzzle_thread"
 task :update_puzzle_thread, %i[day channel] => :environment do |_, args|
   next p "day param missing" if args[:day].nil?
-  next p "channel missing or incorrect" unless args[:channel].in? %w[aoc aoc-dev]
+  next p "channel missing or incorrect" unless args[:channel].in? %w[C02PN711H09 C064BH3TLGJ]
 
   puzzle = Puzzle.by_date(Aoc.begin_time.change(day: args[:day]))
   next p "Puzzle not found" if puzzle.nil?


### PR DESCRIPTION
## Summary of changes and context
This PR fixes a few bugs and adds one improvement
- use `#aoc-dev` channel ID instead of channel name because some Slack API endpoints don't work with the name (Production needs to be update to use `C02PN711H09` for the `SLACK_CHANNEL` ENV now)
- fixed a stupid mistake I made in `GenerateSlackThread#permalink` where I would directly capture the :permalink attribute as the response then try to do `response["ok"]`
- The GenerateSlackThread is supposed to be idempotent in case it fails and is retried (because we don't want to create multiple Puzzle/slack thread) but I wasn't persisting the data as it went so rerunning the job after failing to get the permalink would create a thread again despite it being already done previously
- `@puzzle` is conditionally chained in the `day/:day` page to avoid raising an error when a user tries to access the page before the Job is initially run

The improvement is updating the existing thread message instead of replying message when a snippet is created to avoid spam
![image](https://github.com/user-attachments/assets/570e01ac-940f-42bc-9135-e656ae018dcf)

## Sanity checks

<!-- Add more checks if you did more -->

- [x] Linters pass
- [x] Tests pass
- [x] Related GitHub issues are linked in the description
- [x] Merge conflicts are resolved
